### PR TITLE
dropdown 활성화 후 다른 영역 클릭시 비활성화 하도록 한다

### DIFF
--- a/src/components/organisms/Modal/StudyMakeModal/StudyMakeModal.js
+++ b/src/components/organisms/Modal/StudyMakeModal/StudyMakeModal.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -153,6 +153,33 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+const initSelect = {
+  industry: false,
+  job: false,
+};
+
+const industryList = [
+  '경영/사무',
+  '마케팅/MD',
+  '영업',
+  'IT/인터넷',
+  '연구개발/설계',
+  '생산/품질',
+  '디자인',
+  '기타',
+];
+
+const jobList = [
+  '금융/은행',
+  'IT',
+  '서비스/교육',
+  '보건/의약/바이오',
+  '제조',
+  '건설',
+  '예술/문화',
+  '기타',
+];
+
 export default function StudyStartModal({ func }) {
   const classes = useStyles();
   const dispatch = useDispatch();
@@ -160,35 +187,10 @@ export default function StudyStartModal({ func }) {
   const [description, setDescription] = useState();
   const [industry, setIndustry] = useState('산업을 선택해주세요.');
   const [job, setJob] = useState('직무를 선택해주세요.');
-  const [select, setSelect] = useState({
-    industry: false,
-    job: false,
-  });
+  const [select, setSelect] = useState(initSelect);
+
   const [date, setDate] = useState(moment(new Date()).format('YYYY-MM-DD'));
-
   const [time, setTime] = useState(moment(new Date()).format('HH:mm'));
-
-  const industryList = [
-    '경영/사무',
-    '마케팅/MD',
-    '영업',
-    'IT/인터넷',
-    '연구개발/설계',
-    '생산/품질',
-    '디자인',
-    '기타',
-  ];
-
-  const jobList = [
-    '금융/은행',
-    'IT',
-    '서비스/교육',
-    '보건/의약/바이오',
-    '제조',
-    '건설',
-    '예술/문화',
-    '기타',
-  ];
 
   const handleInputChange = (e, setState) => {
     setState(e.target.value);
@@ -234,6 +236,23 @@ export default function StudyStartModal({ func }) {
     });
   };
 
+  const industryRef = useRef();
+  const jobRef = useRef();
+
+  function handleClickOutside({ target }) {
+    if (
+      !industryRef.current.contains(target)
+      && !jobRef.current.contains(target)
+    ) {
+      setSelect(initSelect);
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, []);
+
   return (
     <>
       <Wrapper>
@@ -256,7 +275,7 @@ export default function StudyStartModal({ func }) {
         <SelectWrapper>
           <LeftWrapper>
             <InputText>산업</InputText>
-            <SelectList>
+            <SelectList ref={industryRef}>
               <Select onClick={() => handleToggle('industry')}>
                 <SelectText>{industry}</SelectText>
                 <A.Icon type="arrow_down_blue" alt="" />
@@ -267,7 +286,8 @@ export default function StudyStartModal({ func }) {
                     {industryList.map((val) => (
                       <SelectItem>
                         <SelectText
-                          onClick={() => handleSelect(setIndustry, val, 'industry')}
+                          onClick={() => handleSelect(setIndustry, val, 'industry')
+                          }
                         >
                           {val}
                         </SelectText>
@@ -295,7 +315,7 @@ export default function StudyStartModal({ func }) {
           </LeftWrapper>
           <RightWrapper>
             <InputText>직무</InputText>
-            <SelectList>
+            <SelectList ref={jobRef}>
               <Select onClick={() => handleToggle('job')}>
                 <SelectText>{job}</SelectText>
                 <A.Icon type="arrow_down_blue" alt="" />

--- a/src/components/organisms/Modal/StudyMakeModal/StudyMakeModal.js
+++ b/src/components/organisms/Modal/StudyMakeModal/StudyMakeModal.js
@@ -202,7 +202,7 @@ export default function StudyStartModal({ func }) {
   };
 
   const handleToggle = (type) => {
-    setSelect({ ...select, [type]: !select[type] });
+    setSelect({ [type]: !select[type] });
   };
 
   const handleChangeDate = (e) => {

--- a/src/pages/SignUpPage/SignUpPage.js
+++ b/src/pages/SignUpPage/SignUpPage.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-escape */
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import styled from 'styled-components';
@@ -250,7 +250,7 @@ const EMPTY_FORM = {
   subJob: '',
 };
 
-const industryList = [
+const jobList = [
   '경영/사무',
   '마케팅/MD',
   '영업',
@@ -261,7 +261,7 @@ const industryList = [
   '기타',
 ];
 
-const jobList = [
+const industryList = [
   '금융/은행',
   'IT',
   '서비스/교육',
@@ -360,6 +360,28 @@ export default function SignUpPage({ history }) {
       });
   };
 
+  const industryMainRef = useRef();
+  const industrySubRef = useRef();
+
+  const jobMainRef = useRef();
+  const jobSubRef = useRef();
+
+  function handleClickOutside({ target }) {
+    if (
+      !industryMainRef.current.contains(target)
+      && !industrySubRef.current.contains(target)
+      && !jobMainRef.current.contains(target)
+      && !jobSubRef.current.contains(target)
+    ) {
+      setSelect(initSelect);
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, []);
+
   return (
     <Wrapper ratio={ratio > 1.675}>
       {authSelector.isLogin && <Redirect to="/self" />}
@@ -419,7 +441,7 @@ export default function SignUpPage({ history }) {
               <WrapUpperContainer>
                 <WrapInput ratio={ratio > 1.675}>
                   <WrapText>관심 산업_Main</WrapText>
-                  <SelectList>
+                  <SelectList ref={industryMainRef}>
                     <Select
                       onClick={() => handleToggle('mainIndustry')}
                       ratio={ratio > 1.675}
@@ -436,7 +458,8 @@ export default function SignUpPage({ history }) {
                                 setMainIndustry,
                                 val,
                                 'mainIndustry',
-                              )}
+                              )
+                              }
                             >
                               <SelectText>{val}</SelectText>
                             </SelectItem>
@@ -448,7 +471,7 @@ export default function SignUpPage({ history }) {
                 </WrapInput>
                 <WrapInput ratio={ratio > 1.675}>
                   <WrapText>관심 산업_Sub</WrapText>
-                  <SelectList>
+                  <SelectList ref={industrySubRef}>
                     <Select
                       onClick={() => handleToggle('subIndustry')}
                       ratio={ratio > 1.675}
@@ -461,7 +484,8 @@ export default function SignUpPage({ history }) {
                         <SelectItemList>
                           {industryList.map((val) => (
                             <SelectItem
-                              onClick={() => handleSelect(setSubIndustry, val, 'subIndustry')}
+                              onClick={() => handleSelect(setSubIndustry, val, 'subIndustry')
+                              }
                             >
                               <SelectText>{val}</SelectText>
                             </SelectItem>
@@ -475,7 +499,7 @@ export default function SignUpPage({ history }) {
               <WrapUpperContainer>
                 <WrapInput ratio={ratio > 1.675}>
                   <WrapText>관심 직무_Main</WrapText>
-                  <SelectList>
+                  <SelectList ref={jobMainRef}>
                     <Select
                       onClick={() => handleToggle('mainJob')}
                       ratio={ratio > 1.675}
@@ -488,7 +512,8 @@ export default function SignUpPage({ history }) {
                         <SelectItemList>
                           {jobList.map((val) => (
                             <SelectItem
-                              onClick={() => handleSelect(setMainJob, val, 'mainJob')}
+                              onClick={() => handleSelect(setMainJob, val, 'mainJob')
+                              }
                             >
                               <SelectText>{val}</SelectText>
                             </SelectItem>
@@ -500,7 +525,7 @@ export default function SignUpPage({ history }) {
                 </WrapInput>
                 <WrapInput ratio={ratio > 1.675}>
                   <WrapText>관심 직무_Sub</WrapText>
-                  <SelectList>
+                  <SelectList ref={jobSubRef}>
                     <Select
                       onClick={() => handleToggle('subJob')}
                       ratio={ratio > 1.675}
@@ -513,7 +538,8 @@ export default function SignUpPage({ history }) {
                         <SelectItemList>
                           {jobList.map((val) => (
                             <SelectItem
-                              onClick={() => handleSelect(setSubJob, val, 'subJob')}
+                              onClick={() => handleSelect(setSubJob, val, 'subJob')
+                              }
                             >
                               <SelectText>{val}</SelectText>
                             </SelectItem>
@@ -533,12 +559,12 @@ export default function SignUpPage({ history }) {
                   func={() => setToggleCheckTerm({
                     ...toggleCheckTerm,
                     first: !toggleCheckTerm.first,
-                  })}
+                  })
+                  }
                 />
                 <WrapMiddleText ratio={ratio > 1}>
                   {/* TODO: 병헌님이 작업해주시면 추가 */}
-                  <ClickableSelectText>이용약관</ClickableSelectText>
-                  에 모두
+                  <ClickableSelectText>이용약관</ClickableSelectText>에 모두
                   동의합니다.
                 </WrapMiddleText>
               </WrapMiddlePart>
@@ -548,12 +574,12 @@ export default function SignUpPage({ history }) {
                   func={() => setToggleCheckTerm({
                     ...toggleCheckTerm,
                     second: !toggleCheckTerm.second,
-                  })}
+                  })
+                  }
                 />
                 <WrapMiddleText ratio={ratio > 1}>
                   {/* TODO: 병헌님이 작업해주시면 추가 */}
-                  <ClickableSelectText>개인정보처리방침</ClickableSelectText>
-                  에
+                  <ClickableSelectText>개인정보처리방침</ClickableSelectText>에
                   모두 동의합니다.
                 </WrapMiddleText>
               </WrapMiddlePart>
@@ -561,7 +587,11 @@ export default function SignUpPage({ history }) {
           </WrapContianer>
           <WrapButton>
             {/* TODO: 회원가입 로직 추기 */}
-            <A.Button theme="blue" text="회원가입" func={() => handleSignUp()} />
+            <A.Button
+              theme="blue"
+              text="회원가입"
+              func={() => handleSignUp()}
+            />
           </WrapButton>
         </WrapBox>
         <WrapBottomContainer>


### PR DESCRIPTION
> resolve #11 

## Detail & Solution
1. dropdown에 해당하는 DOM의 ref attribute를 useRef로 선택합니다.
2. 컴포넌트 마운트시 window.addEventListener("click", <function>);을 실행하도록 하고 언마운트시 removeEventListener를 해주도록 합니다.
3. 해당 function에 각 useRef의 current와 클릭시 event.target이 일치하는 경우가 아니면 상태를 초기화해서 dropdown을 비활성화 하도록 합니다. 즉, dropbox가 활성화된 상태에서 dropbox가 아닌 영역을 클릭할 경우 함수를 실행하게 됩니다.

dropbox가 있는 페이지에서는 항상 2개 이상씩 존재하기때문에 갯수만큼 useRef로 해당 DOM을 선택하게끔 했습니다. 이 방법이 최적의 방법인지는 모르겠습니다.

## What I did
회원가입 페이지 및 스터디 생성 Modal에서 dropdown을 클릭하여 활성화한 뒤 dropdown이 아닌 영역을 클릭했을 때 비활성화되도록 수정했습니다.

## What I need to do 

## Reference
- https://velog.io/@seungdeng17/%EB%AA%A8%EB%8B%AC-%EC%98%81%EC%97%AD-%EB%B0%96-%ED%81%B4%EB%A6%AD%EC%8B%9C-%EC%89%BD%EA%B2%8C-%EB%8B%AB%EA%B8%B0
