### PR TITLE
actions workflow 새 organization에 맞게 migrate한다

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,8 +2,6 @@ name: Storybook
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
 
 jobs:
   build-and-deploy:
@@ -27,36 +25,38 @@ jobs:
       - run: npm ci
       - run: npm run build-storybook
 
-      # extract branch name
-      - name: Get branch name (merge)
+      - name: Get branch name (push)
         if: github.event_name != 'pull_request'
         shell: bash
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/#//')" >> $GITHUB_ENV
 
-      - name: Get branch name (pull request)
+      - name: Get branch name (pull_request)
         if: github.event_name == 'pull_request'
         shell: bash
         run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | sed 's/#//')" >> $GITHUB_ENV
 
-      - name: Debug
-        run: echo ${{ env.BRANCH_NAME }}
+      - name: Get user name
+        shell: bash
+        run: echo "USER_NAME=${GITHUB_ACTOR}" >> $GITHUB_ENV
 
-      - name: Deploy to Github Pages(pr)
+      - name: Debug
+        run: echo ${{ env.BRANCH_NAME }} && echo ${{ env.USER_NAME }}
+
+      - name: Deploy to Github Pages(push)
         uses: peaceiris/actions-gh-pages@v3
         if: env.BRANCH_NAME != 'master'
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./storybook-static
           keep_files: true
           destination_dir: ${{ env.BRANCH_NAME }}
-          commit_message: https://Yapp-17th.github.io/Web_2_Client/${{ env.BRANCH_NAME }}
-          
+          commit_message: https://${{ env.USER_NAME }}.github.io/witherview_frontend/${{ env.BRANCH_NAME }}
+
       - name: Deploy to Github Pages(master)
         uses: peaceiris/actions-gh-pages@v3
         if: env.BRANCH_NAME == 'master'
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./storybook-static
           keep_files: true
-          commit_message: https://Yapp-17th.github.io/Web_2_Client/
-          
+          commit_message: https://${{ env.USER_NAME }}.github.io/witherview_frontend/

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,16 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - run: npm ci
-      - run: npm run build-storybook
+      - name: Install dependencies
+        run: yarn install --prefer-offline --frozen-lockfile
+
+      - name: Build Storybook
+        run: yarn build-storybook
 
       - name: Get branch name (push)
         if: github.event_name != 'pull_request'
@@ -39,10 +39,7 @@ jobs:
         shell: bash
         run: echo "USER_NAME=${GITHUB_ACTOR}" >> $GITHUB_ENV
 
-      - name: Debug
-        run: echo ${{ env.BRANCH_NAME }} && echo ${{ env.USER_NAME }}
-
-      - name: Deploy to Github Pages(push)
+      - name: Deploy to Github Pages
         uses: peaceiris/actions-gh-pages@v3
         if: env.BRANCH_NAME != 'master'
         with:


### PR DESCRIPTION
> resolve #15

## Detail & Solution
지금까지 Storybook 배포는 PR 혹은 master로 머지되는 경우 GitHub Actions를 통해 빌드하여 GitHub Pages로 배포되도록 파이프라인을 구축하였습니다. - [배포 현황](https://github.com/Yapp-17th/Web_2_Client/commits/gh-pages)

배포는 브랜치별로 되도록 빌드된 파일을 브랜치명 폴더에 담도록 처리한 상황이었으며 컴포넌트 등을 새로 만든 경우 해당 브랜치의 URL을 공유하면 바로 확인할 수 있도록 하고자 하는 의도였습니다.

ex) [master 브랜치 스토리북](https://yapp-17th.github.io/Web_2_Client/) / [feat/#73 브랜치 스토리북](https://yapp-17th.github.io/Web_2_Client/feat/73/)

기존 프로젝트 진행은 fork 절차 없이 브랜치로 나눠서 브랜치간의 PR로 작업이 되어 GitHub secrets나 GITHUB_TOKEN의 권한에 대해 생각하지 않아도 되었습니다. 

프로젝트 진행에 fork 절차를 추가한 결과 권환 문제가 생겨 이를 해결하고자 했습니다.

포크받은 origin 리포지토리에서 upstream으로 PR시 GitHub Actions에서 Secrets에 정의해놓은 토큰이 사용 가능한지 + GITHUB_TOKEN 사용이 가능한지 실험해보았습니다.

결론적으로 위와 같은 상황에서 upstream의 Secrets Token 사용 혹은 기본으로 제공해주는 GITHUB_TOKEN 사용이 불가능합니다.

https://github.community/t/make-fork-secrets-available-to-fork-prs/17762 *

https://github.community/t/make-secrets-available-to-builds-of-forks/16166/25

https://github.com/codecov/codecov-action/issues/29

## What I did

1.  Personal Access Token으로 정의했던 것을 GitHub App으로 토큰으로 변경 (실패)
GitHua App으로 생성한 토큰을 Secret에 정의했지만 실패했습니다. 
<img width="292" alt="Screen Shot 2021-03-17 at 12 01 24 AM" src="https://user-images.githubusercontent.com/16266103/111331095-eab60f00-86b3-11eb-9700-531b92e2cbfa.png">

2. Organization 토큰을 설정 (실패)

3. 자체적으로 제공하는 GITHUB_TOKEN을 사용 (실패)
[fork 받은 브랜치에서는 READ only permission](https://github.com/ad-m/github-push-action/issues/40#issuecomment-566368569)이기 때문에 GitHub Actions을 통한 push 이벤트시 403 에러가 발생합니다.

4. Organization settings에 옵션을 킴 (실패)
fork 받은 branch에서 upstream으로 향하는게 아닌 자기 자신으로 향하는 PR에 Secrets를 전달하는 옵션이었습니다.
<img width="1106" alt="Screen Shot 2021-03-18 at 7 54 07 PM" src="https://user-images.githubusercontent.com/16266103/111615464-1f48d880-8824-11eb-83f0-54b5fe729281.png">

5. PR 및 master merge 기준으로 trigger 되던 workflow를 모든 push기반으로 trigger되도록 처리 (타협)
push 기반으로하면 upstream이 아닌 fork 받은 리포지토리 자체적으로 workflow가 실행됩니다. 따라서 기존에 발생했던 이슈를 해결할 수 있습니다. 다만, storybook URL은 PR이 merge되는게 아닌이상 fork된 repository에 따라 바뀌게 됩니다. 해당 URL은 gh-pages branch의 커밋메시지에서 확인 가능합니다. 

> https://<fork 받은 user>.github.io/witherview_frontend/<push 한 branch>

## What I need to do 