### PR TITLE
ISSUE_TEMPLATE 및 PR_TEMPLATE 을 추가한다

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+## **Describe the bug**
+A clear and concise description of what the bug is.
+
+## **To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## **Expected behavior**
+A clear and concise description of what you expected to happen.
+
+## **Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+## **Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+## **Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+## **Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+## **Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## **Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+## **Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+## **Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,26 @@
+---
+name: Question
+about: When you want to ask a question
+---
+
+<!--
+  To make it easier for us to help you, please include as much useful information as possible.
+
+  Useful Links:
+  - tutorial: https://github.com/nhn/tui.editor/tree/master/docs
+  - API/Example: https://nhn.github.io/tui.editor/latest/
+
+  Before opening a new issue, please search existing issues https://github.com/nhn/tui.editor/issues
+-->
+
+## **Summary**
+A clear and concise description of what the question is.
+
+## **Screenshots**
+If applicable, add screenshots to help explain your question.
+
+## **Version**
+Write the version of the Editor you are currently using.
+
+## **Additional context**
+Add any other context about the problem here.

--- a/.github/PR_TEMPLATE/default.md
+++ b/.github/PR_TEMPLATE/default.md
@@ -1,0 +1,8 @@
+> resolve #<Issue Number>
+
+## Detail & Solution
+
+## What I did
+
+## What I need to do
+


### PR DESCRIPTION
> resolve #17

## Detail & Solution
[nhn/fe.javascript](https://github.com/nhn/fe.javascript/blob/master/.github/commit-message-convention.md), [class101-ui](https://github.com/pedaling/class101-ui/pulls?page=1&q=is%3Apr+is%3Aclosed), [line-liff-v2-starter](https://github.com/line/line-liff-v2-starter/tree/master/.github/ISSUE_TEMPLATE) 등을 참고해서 템플릿을 작성하고자 했다.

## What I did
미리 정리해둔 ISSUE 및 PR 템플릿을 사용할 수 있도록 추가했다.

## What I need to do 
