### PR TITLE
sourcemap에 맞춰 Webpack error log 가 나오도록 설정한다

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,6 +124,7 @@ module.exports = (env) => {
     devServer: {
       host: 'localhost',
       port,
+      stats: 'errors-only',
       open: true,
       historyApiFallback: true,
     },


### PR DESCRIPTION
> resolve #21

## Detail & Solution
디버깅 할 때 습관적으로 브라우저에서 했었는데 생각해보니 CRA처럼 sourcemap 매핑헤서 error log가 발생하도록 하면 훨씬 효율적이라는 것을 깨달았습니다.

## What I did
webpack developer 옵션에서의 [devtool](https://webpack.js.org/configuration/devtool/#devtool) 설정은 이미 되어있으므로 [devServer/stats 옵션](https://webpack.js.org/configuration/stats/)을 errors-only로 넣어주면 [sourcemap](https://joshua1988.github.io/webpack-guide/devtools/source-map.html)에 맞춰 error로그가 발생됩니다.

<img width="904" alt="Screen Shot 2021-03-19 at 12 47 52 AM" src="https://user-images.githubusercontent.com/16266103/111725189-f703bd00-88a9-11eb-85dc-452a2f478e56.png">

## What I need to do 
