### PR TITLE
사이드바 디자인 변경 및 트랜지션을 추가한다

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -82,25 +82,26 @@ export default function App() {
             <Route exact path="/self" component={SelfTrainEntryPage} />
             <R.AuthRoute
               exact
-              path="/questionlist"
+              path="/self/questionlist"
               component={QuestionListPage}
             />
-            <R.AuthRoute path="/question/:id" component={QuestionPage} />
+            <R.AuthRoute exact path="/self/question/:id" component={QuestionPage} />
             <R.AuthRoute
+              exact
               path="/self/setting/:id"
               component={SelfTrainSettingPage}
             />
-            <R.AuthRoute path="/self-train/:id" component={SelfTrainPage} />
+            <R.AuthRoute exact path="/self/train/:id" component={SelfTrainPage} />
             <R.AuthRoute
               exact
-              path="/self-checklist/:roomId"
+              path="/self/checklist/:roomId"
               component={SelfStudyChecklist}
             />
-            <R.AuthRoute exact path="/myvideo" component={MyVideoPage} />
-            <R.AuthRoute exact path="/video/:id" component={VideoPage} />
-            <R.AuthRoute path="/peer-study" component={PeerStudyMainPage} />
-            <R.AuthRoute path="/peer/:id" component={R.PeerStudyRoute} />
-            <R.AuthRoute path="/mypage" component={MyPage} />
+            <R.AuthRoute exact path="/replay" component={MyVideoPage} />
+            <R.AuthRoute exact path="/replay/:id" component={VideoPage} />
+            <R.AuthRoute exact path="/peer-study" component={PeerStudyMainPage} />
+            <R.AuthRoute exact path="/peer-study/:id" component={R.PeerStudyRoute} />
+            <R.AuthRoute exact path="/mypage" component={MyPage} />
           </WrapPage>
         </Wrapper>
         <R.AuthRoute component={NotFound} />

--- a/src/components/organisms/Modal/QuestionListSaveModal/QuestionListSaveModal.js
+++ b/src/components/organisms/Modal/QuestionListSaveModal/QuestionListSaveModal.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { hideModal, showModal } from '@store/Modal/modal';
 import { setJob, setCompany, setSelectedQnaId } from '@store/Train/train';
 import A from '@atoms';
@@ -55,6 +56,7 @@ const ButtonWrapper = styled.div`
 `;
 
 const QuestionListSaveModal = () => {
+  const { pathname } = useLocation();
   const dispatch = useDispatch();
   const { questions } = useSelector(get('question'));
 
@@ -70,7 +72,7 @@ const QuestionListSaveModal = () => {
           listId: response.data.id,
           questions,
         }).then(() => {
-          const qnaId = window.location.pathname.replace('/question/', '');
+          const qnaId = pathname.replace('/self/question/', '');
           dispatch(setJob({ job: position }));
           dispatch(setCompany({ company: enterprise }));
           if (qnaId !== 'new') {

--- a/src/components/organisms/QuestionCardView/QuestionCardView.js
+++ b/src/components/organisms/QuestionCardView/QuestionCardView.js
@@ -179,7 +179,7 @@ export default function QuestionCardView({
   const history = useHistory();
 
   const handleMove = () => {
-    history.push(`/question/${id}`);
+    history.push(`/self/question/${id}`);
   };
 
   const toggle = (set) => setIsOpen(set);

--- a/src/components/organisms/Sidebar/SideBar.js
+++ b/src/components/organisms/Sidebar/SideBar.js
@@ -65,11 +65,11 @@ export default function SideBar() {
 
   useEffect(() => {
     const pathName = pathname.split('/')[1];
-    if (pathName === 'self' || pathName === 'peer-study' || pathName === 'myvideo' || pathName === 'mypage') {
-      return setPath(pathName);
+    if (pathName === 'self' || pathName === 'peer-study' || pathName === 'replay' || pathName === 'mypage') {
+      setPath(pathName);
+    } else {
+      history.push('/self');
     }
-    history.push('/self');
-    return null;
   }, []);
 
   const handleClick = (value) => {
@@ -94,9 +94,9 @@ export default function SideBar() {
           clicked={path === 'peer-study'}
         />
         <SidebarButton
-          func={() => handleClick('myvideo')}
-          type={path === 'myvideo' ? 'folder_blue' : 'folder_white'}
-          clicked={path === 'myvideo'}
+          func={() => handleClick('replay')}
+          type={path === 'replay' ? 'folder_blue' : 'folder_white'}
+          clicked={path === 'replay'}
         />
         <SidebarButton
           func={() => handleClick('mypage')}

--- a/src/components/organisms/Sidebar/SideBar.js
+++ b/src/components/organisms/Sidebar/SideBar.js
@@ -6,39 +6,40 @@ import styled from 'styled-components';
 
 import { setLogout } from '@store/Auth/auth';
 
-import LogoWithTitle from '@assets/images/witherview_logo_title.png';
 import Logo from '@assets/images/witherview_logo.png';
 import SidebarButton from './SidebarButton';
 
 const Wrapper = styled.div`
   position: fixed;
-  width: ${({ hover }) => (hover ? 29.6 : 15.9)}vh;
-  min-width: 15.9vh;
-  max-width: 29.6vh;
+  width: 10vh;
+  min-width: 10vh;
+  max-width: 15.9vh;
   height: 100vh;
   min-height: 20vh;
   border: none;
   background-color: #0c0c59;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -o-user-select: none;
   user-select: none;
   z-index: 10;
+  transition: all ease 0.1s 0.1s;
+
+  &:hover {
+    width: 15.9vh;
+    box-shadow: 0.3vh 0 1.1vh 0 rgba(50, 50, 50, 0.56);
+    transition: width ease 0.2s 0.5s;
+  }
 `;
 
 const WrapTopButton = styled.div`
   position: absolute;
-  top: 7.2vh;
-  width: ${({ hover }) => (hover ? 29.6 : 15.9)}vh;
+  top: 5vh;
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
 `;
 
 const WrapImage = styled.img`
-  height: ${({ hover }) => (hover ? 3 : 5)}vh;
-  padding: ${({ hover }) => (hover ? 1 : 0)}vh;
+  height: 6vh;
 `;
 
 const WrapButtonContainer = styled.div`
@@ -46,19 +47,18 @@ const WrapButtonContainer = styled.div`
 `;
 
 const WrapBottomButton = styled.div`
-  width: ${({ hover }) => (hover ? 29.6 : 15.9)}vh;
+  width: 100%;
   position: absolute;
   align-items: center;
   justify-content: center;
   display: flex;
-  bottom: 9.79vh;
+  bottom: 8vh;
 `;
 
 export default function SideBar() {
   const dispatch = useDispatch();
   const history = useHistory();
   const [click, setClick] = useState(0);
-  const [hover, setHover] = useState(false);
 
   const handleClick = (value) => {
     setClick(value);
@@ -73,57 +73,34 @@ export default function SideBar() {
     );
   };
 
-  function hoverActive() {
-    setHover(true);
-  }
-  function hoverDeactive() {
-    setHover(false);
-  }
-
   return (
-    <Wrapper
-      onMouseEnter={hoverActive}
-      onMouseLeave={hoverDeactive}
-      hover={hover}
-    >
-      <WrapTopButton hover={hover}>
-        <WrapImage
-          src={hover ? LogoWithTitle : Logo}
-          hover={hover}
-          alt="logo"
-        />
+    <Wrapper>
+      <WrapTopButton>
+        <WrapImage src={Logo} alt="logo" />
       </WrapTopButton>
       <WrapButtonContainer>
         <SidebarButton
           func={() => handleClick(0)}
           type={click === 0 ? 'bubble_black' : 'bubble_white'}
           clicked={click === 0}
-          hover={hover}
-          title="혼자연습"
         />
         <SidebarButton
           func={() => handleClick(1)}
           type={click === 1 ? 'sound_black' : 'sound_white'}
           clicked={click === 1}
-          hover={hover}
-          title="면접스터디"
         />
         <SidebarButton
           func={() => handleClick(4)}
           type={click === 4 ? 'folder_blue' : 'folder_white'}
           clicked={click === 4}
-          hover={hover}
-          title="저장확인"
         />
         <SidebarButton
           func={() => handleClick(2)}
           type={click === 2 ? 'profile_black' : 'profile_white'}
           clicked={click === 2}
-          hover={hover}
-          title="마이페이지"
         />
       </WrapButtonContainer>
-      <WrapBottomButton hover={hover}>
+      <WrapBottomButton>
         <SidebarButton
           func={() => {
             dispatch(setLogout());
@@ -131,7 +108,6 @@ export default function SideBar() {
           }}
           type={click === 3 ? 'exit_blue' : 'exit_white'}
           clicked={click === 3}
-          hover={hover}
           title="나가기"
         />
       </WrapBottomButton>

--- a/src/components/organisms/Sidebar/SideBar.js
+++ b/src/components/organisms/Sidebar/SideBar.js
@@ -1,6 +1,6 @@
 /* eslint-disable indent */
-import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
@@ -56,21 +56,25 @@ const WrapBottomButton = styled.div`
 `;
 
 export default function SideBar() {
-  const dispatch = useDispatch();
+  const { pathname } = useLocation();
   const history = useHistory();
-  const [click, setClick] = useState(0);
+
+  const dispatch = useDispatch();
+
+  const [path, setPath] = useState('self');
+
+  useEffect(() => {
+    const pathName = pathname.split('/')[1];
+    if (pathName === 'self' || pathName === 'peer-study' || pathName === 'myvideo' || pathName === 'mypage') {
+      return setPath(pathName);
+    }
+    history.push('/self');
+    return null;
+  }, []);
 
   const handleClick = (value) => {
-    setClick(value);
-    history.push(
-      value === 0
-        ? '/self'
-        : value === 1
-        ? '/peer-study'
-        : value === 2
-        ? '/mypage'
-        : 'myvideo',
-    );
+    setPath(value);
+    history.push(`/${value}`);
   };
 
   return (
@@ -80,24 +84,24 @@ export default function SideBar() {
       </WrapTopButton>
       <WrapButtonContainer>
         <SidebarButton
-          func={() => handleClick(0)}
-          type={click === 0 ? 'bubble_black' : 'bubble_white'}
-          clicked={click === 0}
+          func={() => handleClick('self')}
+          type={path === 'self' ? 'bubble_black' : 'bubble_white'}
+          clicked={path === 'self'}
         />
         <SidebarButton
-          func={() => handleClick(1)}
-          type={click === 1 ? 'sound_black' : 'sound_white'}
-          clicked={click === 1}
+          func={() => handleClick('peer-study')}
+          type={path === 'peer-study' ? 'sound_black' : 'sound_white'}
+          clicked={path === 'peer-study'}
         />
         <SidebarButton
-          func={() => handleClick(4)}
-          type={click === 4 ? 'folder_blue' : 'folder_white'}
-          clicked={click === 4}
+          func={() => handleClick('myvideo')}
+          type={path === 'myvideo' ? 'folder_blue' : 'folder_white'}
+          clicked={path === 'myvideo'}
         />
         <SidebarButton
-          func={() => handleClick(2)}
-          type={click === 2 ? 'profile_black' : 'profile_white'}
-          clicked={click === 2}
+          func={() => handleClick('mypage')}
+          type={path === 'mypage' ? 'profile_black' : 'profile_white'}
+          clicked={path === 'mypage'}
         />
       </WrapButtonContainer>
       <WrapBottomButton>
@@ -106,8 +110,7 @@ export default function SideBar() {
             dispatch(setLogout());
             history.push('/');
           }}
-          type={click === 3 ? 'exit_blue' : 'exit_white'}
-          clicked={click === 3}
+          type="exit_white"
           title="나가기"
         />
       </WrapBottomButton>

--- a/src/components/organisms/Sidebar/SidebarButton/SideBarButton.js
+++ b/src/components/organisms/Sidebar/SidebarButton/SideBarButton.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import A from '@atoms';
 
 const Wrapper = styled.button`
-  width: ${({ hover }) => (hover ? 29.6 : 15.9)}vh;
+  width: 100%;
   height: 7.1vh;
   background-color: ${({ clicked }) => (clicked ? 'white' : '#0c0c59')};
   display: flex;
@@ -21,22 +21,10 @@ const Wrapper = styled.button`
   cursor: pointer;
 `;
 
-const WrapText = styled.div`
-  width: 11.4vh;
-  padding-left: 1.9vh;
-  font-family: AppleSDGothicNeoB00;
-  font-size: 1.9vh;
-  text-align: left;
-  color: ${({ clicked }) => (clicked ? '#0c0c59' : 'white')};
-`;
-
-export default function SideBarButton({
-  type, clicked, func, hover, title,
-}) {
+export default function SideBarButton({ type, clicked, func }) {
   return (
-    <Wrapper onClick={func} clicked={clicked} hover={hover}>
+    <Wrapper onClick={func} clicked={clicked}>
       <A.Icon type={type} alt="icon" />
-      {hover && <WrapText clicked={clicked}>{title}</WrapText>}
     </Wrapper>
   );
 }
@@ -45,12 +33,8 @@ SideBarButton.propTypes = {
   type: PropTypes.string.isRequired,
   clicked: PropTypes.bool,
   func: PropTypes.func.isRequired,
-  hover: PropTypes.bool,
-  title: PropTypes.string,
 };
 
 SideBarButton.defaultProps = {
   clicked: false,
-  hover: false,
-  title: '',
 };

--- a/src/components/organisms/StudyCardView/StudyCardView.js
+++ b/src/components/organisms/StudyCardView/StudyCardView.js
@@ -161,7 +161,7 @@ export default function StudyCardView({
         }
       });
     });
-    history.push(`/peer/${id}`);
+    history.push(`/peer-study/${id}`);
   };
   return (
     <Wrapper>

--- a/src/pages/MyVideoPage/MyVideoPage.js
+++ b/src/pages/MyVideoPage/MyVideoPage.js
@@ -123,7 +123,7 @@ export default function MyVideoPage() {
                     role="checkbox"
                     tabIndex={-1}
                     key={row.code}
-                    onClick={() => history.push(`/video/${row.id}`)}
+                    onClick={() => history.push(`/replay/${row.id}`)}
                   >
                     {columns.map((column) => {
                       const value = row[column.id];

--- a/src/pages/QuestionListPage/IsQuestionList/IsQuestionList.js
+++ b/src/pages/QuestionListPage/IsQuestionList/IsQuestionList.js
@@ -52,7 +52,7 @@ export default function IsQuestionList({ questionList, handleDelete }) {
     <>
       <Wrapper>
         <ItemWrapper>
-          <Link to="/question/new" style={{ textDecoration: 'none' }}>
+          <Link to="/self/question/new" style={{ textDecoration: 'none' }}>
             <AddQuestionList>
               <IconWrapper>
                 <A.Icon type="add_black" alt="icon" />

--- a/src/pages/QuestionListPage/NoList/NoList.js
+++ b/src/pages/QuestionListPage/NoList/NoList.js
@@ -49,7 +49,7 @@ export default function NoList() {
     <>
       <Image src={NoListImage} />
       <Text>등록된 질문 리스트가 없습니다.</Text>
-      <Link to="/question/new" style={{ textDecoration: 'none' }}>
+      <Link to="/self/question/new" style={{ textDecoration: 'none' }}>
         <Button>
           <A.Icon type="add_white" alt="" />
           <ButtonText>질문 리스트 등록하기</ButtonText>

--- a/src/pages/SelfStudyChecklistPage/SelfStudyChecklistPage.js
+++ b/src/pages/SelfStudyChecklistPage/SelfStudyChecklistPage.js
@@ -346,7 +346,7 @@ export default function SelfStudyChecklistPage({ match }) {
   );
 
   const selfTraingAgain = useCallback(() => {
-    history.push(`/question/${roomId}`);
+    history.push(`/self/question/${roomId}`);
   }, [roomId]);
 
   const initCheckList = useCallback(() => {

--- a/src/pages/SelfTrainEntryPage/SelfTrainEntryPage.js
+++ b/src/pages/SelfTrainEntryPage/SelfTrainEntryPage.js
@@ -86,7 +86,7 @@ export default function SelfTrainEntryPage({ history }) {
               // TODO: 기본 질문목록 endpoint 재호님이 추가하면 바꿔야 함
               isGuide
                 ? () => history.push('/self/setting/3')
-                : () => history.push('/questionlist')
+                : () => history.push('/self/questionlist')
             }
             theme={clicked ? 'blue' : 'gray'}
             text="다음"

--- a/src/pages/SelfTrainPage/SelfTrainPage.js
+++ b/src/pages/SelfTrainPage/SelfTrainPage.js
@@ -81,7 +81,7 @@ export default function SelfTrainPage({ match }) {
     postPreVideoApi({ questionListId: id }).then((response) => {
       dispatch(setHistoryId({ historyId: response.data.id }));
       stopRecording();
-      history.push(`/self-checklist/${id}`);
+      history.push(`/self/checklist/${id}`);
       dispatch(handleReset({ keepTrain: true }));
     });
   };

--- a/src/pages/SelfTrainSettingPage/SelfTrainSettingPage.js
+++ b/src/pages/SelfTrainSettingPage/SelfTrainSettingPage.js
@@ -142,7 +142,7 @@ export default function SelfTrainSettingPage({ match, history }) {
           <A.Button
             theme={company && job && standardTime > 0 ? 'blue' : 'gray'}
             text="다음"
-            func={() => history.push(`/self-train/${selectedQnaId}`)}
+            func={() => history.push(`/self/train/${selectedQnaId}`)}
           />
         </WrapButton>
       </WrapContent>


### PR DESCRIPTION
> resolve #24

## Detail & Solution
은비님이 MS Edge 브라우저의 사이드바 트랜지션 느낌으로 디자인을 변경하신 부분을 반영하였습니다.

https://user-images.githubusercontent.com/16266103/111889965-81722b00-8a28-11eb-974d-6ed19274e812.mp4

<div>
<img width="90" alt="Screen Shot 2021-03-21 at 9 32 10 AM" src="https://user-images.githubusercontent.com/16266103/111889942-52f45000-8a28-11eb-89f4-c19a5620c7c5.png">
<img width="72" alt="Screen Shot 2021-03-21 at 9 31 31 AM" src="https://user-images.githubusercontent.com/16266103/111889935-3bb56280-8a28-11eb-9c3d-1ebfd37047d3.png">
</div>

## What I did
- styled-components 자체에서 vender prefix를 자동으로 추가해주는데 이를 임의로 적용한 스타일이 있어 제거하였습니다.
- 기존에 js로 관리되던 hover 상태 및 트랜지션을 CSS 기반 트랜지션으로 변경하였습니다.
- 스타일 리펙토링 및 사이드바 버튼 Text를 제거하였습니다.
- #13 에서 JWT 기반으로 변경되어 새로고침을 해도 해당 페이지에 머물 수 있도록 리팩토링 되었습니다. 하지만 새로고침시 SideBar가 버튼이 선택된 위치를 기억하지 못하는 이슈가 있어 url path를 가져와 url에 따라 올바른 버튼이 매핑되어 선택되게끔 수정하였습니다. https://github.com/witherview/witherview_frontend/pull/32/commits/2a8cf2a213cb504a64c73838277a0793aabcdd2b
- 새로고침시 SideBar의 올바른 위치의 버튼이 선택될 수 있도록 하는 로직을 위해 path의 구조를 `/` 를 기준으로 통일하도록 변경하였습니다. https://github.com/witherview/witherview_frontend/pull/32/commits/d380875dda3e00ff4a00ebcdba612baf5948fb50



### Before
[Storybook: SideBar - Before](https://dididy.github.io/witherview_frontend/?path=/story/organisms-side-bar--side-bar)

https://user-images.githubusercontent.com/16266103/113977783-0f01a780-987e-11eb-82de-cb02027e636d.mov

### After
[Storybook: SideBar - After](https://dididy.github.io/witherview_frontend/refactor/sidebar/?path=/story/organisms-side-bar--side-bar)

https://user-images.githubusercontent.com/16266103/113978055-6dc72100-987e-11eb-8112-944c68ff2959.mov

## What I need to do

