### PR TITLE
질문리스트 Box 버블링 방지를 위한 메서드를 추가한다

### DIFF
--- a/src/components/organisms/QuestionCardView/QuestionCardView.js
+++ b/src/components/organisms/QuestionCardView/QuestionCardView.js
@@ -194,7 +194,14 @@ export default function QuestionCardView({
         </IconBox>
         <List isOpen={isOpen} onMouseLeave={() => toggle(false)}>
           <Item>
-            <Each onClick={() => handleDelete(id)}>삭제</Each>
+            <Each
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDelete(id);
+              }}
+            >
+              삭제
+            </Each>
           </Item>
         </List>
         <Content>


### PR DESCRIPTION
> resolve #39

## Detail & Solution
https://user-images.githubusercontent.com/16266103/114490840-7c338500-9c50-11eb-9afc-b00ef9901cf7.mov

```javascript
      <Box onClick={() => handleMove()}>
        <IconBox isOpen={isOpen} onMouseOver={() => toggle(true)}>
          <IconEach />
          <IconEach />
          <IconEach />
        </IconBox>
        <List isOpen={isOpen} onMouseLeave={() => toggle(false)}>
          <Item>
            <Each
              onClick={(e) => handleDelete(id)}
            >
              삭제
            </Each>
          </Item>
        </List>
        ...
      </Box>
```

Each에서 onClick 이벤트 발생시 버블링이 일어나 상위 DOM인 Box의 onClick도 같이 실행되는 이슈가 생겼습니다.

## What I did
`e.stopPropagation();` WebAPI를 사용해서 이벤트가 상위 요소로 전달되는 것을 막도록 처리하였습니다.

https://user-images.githubusercontent.com/16266103/114494431-58277200-9c57-11eb-9cbf-3c1bb42c5d74.mov

## What I need to do

