### PR TITLE
이미지 업로드 로직에 용량제한 및 형식 validation을 추가한다

### DIFF
--- a/src/components/molecules/ProfileEdit/ProfileEdit.js
+++ b/src/components/molecules/ProfileEdit/ProfileEdit.js
@@ -41,23 +41,30 @@ export default function ProfileEdit({ src = profileDefault }) {
   const onChange = (e) => {
     const reader = new FileReader();
     const file = e.target.files[0];
-    reader.readAsDataURL(file);
-    reader.onload = async () => {
-      const formData = new FormData();
-      formData.append('profileImg', file, file.name);
 
-      try {
+    try {
+      if (file.type.match('image.*')) {
+        throw new Error('이미지 파일 형식이 아닙니다.');
+      }
+      if (file.size < 5120 * 1024) {
+        throw new Error('5MB 이하의 이미지 파일만 업로드 가능합니다.');
+      }
+      reader.readAsDataURL(file);
+      reader.onload = async () => {
+        const formData = new FormData();
+        formData.append('profileImg', file, file.name);
         await postProfileImageApi(formData);
         dispatch(setImage({ image: reader.result }));
-      } catch (error) {
+      };
+      reader.onerror = (error) => {
         console.error(error);
         alert(error);
-      }
-    };
-    reader.onerror = (error) => {
+        reader.abort();
+      };
+    } catch (error) {
       console.error(error);
       alert(error);
-    };
+    }
   };
 
   return (

--- a/src/components/molecules/ProfileEdit/ProfileEdit.js
+++ b/src/components/molecules/ProfileEdit/ProfileEdit.js
@@ -46,7 +46,7 @@ export default function ProfileEdit({ src = profileDefault }) {
       if (file.type.match('image.*')) {
         throw new Error('이미지 파일 형식이 아닙니다.');
       }
-      if (file.size < 5120 * 1024) {
+      if (file.size < 5 * 1024 * 1024) {
         throw new Error('5MB 이하의 이미지 파일만 업로드 가능합니다.');
       }
       reader.readAsDataURL(file);

--- a/src/components/organisms/Modal/QuestionListSaveModal/QuestionListSaveModal.js
+++ b/src/components/organisms/Modal/QuestionListSaveModal/QuestionListSaveModal.js
@@ -79,7 +79,7 @@ const QuestionListSaveModal = () => {
         questions,
       });
 
-      const qnaId = window.location.pathname.replace('/question/', '');
+      const qnaId = pathname.replace('/question/', '');
 
       dispatch(setJob({ job: position }));
       dispatch(setCompany({ company: enterprise }));


### PR DESCRIPTION
> resolve #56

## Detail & Solution
#4 에서 적용하지 못한 이미지 업로드 용량 제한 및 형식 validation을 추가해야했습니다.


## What I did
- reader.onerror 시 FileReader()에 해당하는 reader의 abort() 메소드를 실행하는 코드를 추가하였습니다.
- `e.target.files[0]` 에서 type 및 size 에 해당하는 값을 아래와 같이 검증하여 throw new Error()로 에러를 발생시키도록 처리했습니다.

```javascript
   try {
      if (file.type.match('image.*')) {
        throw new Error('이미지 파일 형식이 아닙니다.');
      }
      if (file.size < 5120 * 1024) {
        throw new Error('5MB 이하의 이미지 파일만 업로드 가능합니다.');
      }

      ...

    } catch (error) {
      console.error(error);
      alert(error);
    }
  };
```


## What I need to do

