### PR TITLE
react-router-dom 의 path 수정 반영 못한부분을 수정한다

### DIFF
--- a/src/components/organisms/Modal/QuestionListSaveModal/QuestionListSaveModal.js
+++ b/src/components/organisms/Modal/QuestionListSaveModal/QuestionListSaveModal.js
@@ -79,7 +79,7 @@ const QuestionListSaveModal = () => {
         questions,
       });
 
-      const qnaId = pathname.replace('/question/', '');
+      const qnaId = pathname.replace('/self/question/', '');
 
       dispatch(setJob({ job: position }));
       dispatch(setCompany({ company: enterprise }));

--- a/src/components/organisms/StudyCardView/StudyCardView.js
+++ b/src/components/organisms/StudyCardView/StudyCardView.js
@@ -161,7 +161,7 @@ export default function StudyCardView({
           postGroupRoomParticipantsApi(id);
         }
       });
-      history.push(`/peer/${id}`);
+      history.push(`/peer-study/${id}`);
     } catch (error) {
       console.error(error);
       alert(error);


### PR DESCRIPTION
> resolve #<HOTFIX>

## Detail & Solution
#32 의 https://github.com/witherview/witherview_frontend/pull/32/commits/d380875dda3e00ff4a00ebcdba612baf5948fb50 에서 react-router-dom의 path를 일관되게 변경했던 부분이 로직에 반영 안되어있었습니다.

## What I did
버그가 발생하는 부분의 코드를 수정하였습니다.

## What I need to do

