### PR TITLE
카메라를 사용 후 사용하지 않는 화면에서도 사용중으로 표시되는 에러를 해결한다

### DIFF
--- a/src/components/molecules/SmallCamView/SmallCamView.js
+++ b/src/components/molecules/SmallCamView/SmallCamView.js
@@ -2,6 +2,8 @@ import React, { useEffect, useRef } from 'react';
 
 import styled from 'styled-components';
 
+import { cleanUpStream } from '@utils/snippet';
+
 const Wrapper = styled.div`
   width: 22.6vh;
   height: 15.2vh;
@@ -23,12 +25,20 @@ const WrapVideo = styled.video`
 export default function SmallCamView() {
   const userVideo = useRef();
 
-  useEffect(() => {
+  const setupStream = () => {
     navigator.mediaDevices
       .getUserMedia({ video: true, audio: true })
       .then((stream) => {
-        userVideo.current.srcObject = stream;
+        userVideo.current = stream;
+      })
+      .catch((error) => {
+        console.error(error);
       });
+  };
+
+  useEffect(() => {
+    setupStream();
+    return () => cleanUpStream(userVideo.current.srcObject);
   }, []);
 
   return (

--- a/src/components/organisms/CamView/CamView.js
+++ b/src/components/organisms/CamView/CamView.js
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 
 import M from '@molecules';
 
+import { cleanUpStream } from '@utils/snippet';
+
 const Wrapper = styled.div`
   height: 59vh;
   width: 77.3vh;
@@ -46,6 +48,8 @@ export default function CamView({
         console.error(error);
       });
   };
+
+  useEffect(() => () => cleanUpStream(videoRef.current.srcObject), []);
 
   useEffect(() => {
     setupStream();

--- a/src/hooks/useMediaRecorder.js
+++ b/src/hooks/useMediaRecorder.js
@@ -6,6 +6,8 @@ import { useDispatch } from 'react-redux';
 
 import { setLocalBlob } from '@store/Train/train';
 
+import { cleanUpStream } from '@utils/snippet';
+
 export default function useReactMediaRecorder({
   audio = true,
   video = false,
@@ -25,12 +27,15 @@ export default function useReactMediaRecorder({
   const [mediaBlobUrl, setMediaBlobUrl] = useState(null);
   const [error, setError] = useState('NONE');
 
+  useEffect(() => () => cleanUpStream(mediaStream.current), []);
+
   const getMediaStream = useCallback(async () => {
     setStatus('acquiring_media');
     const requiredMedia = {
       audio: typeof audio === 'boolean' ? !!audio : audio,
       video: typeof video === 'boolean' ? !!video : video,
     };
+
     try {
       if (screen) {
         const stream = await window.navigator.mediaDevices.getDisplayMedia({

--- a/src/pages/PeerStudyTrainPage/MyCamView.js
+++ b/src/pages/PeerStudyTrainPage/MyCamView.js
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 
 import styled from 'styled-components';
 
 import M from '@molecules';
+
+import { cleanUpStream } from '@utils/snippet';
 
 const Wrapper = styled.div`
   width: ${({ peers }) => (peers ? '66.3vh;' : '77.3vh;')}
@@ -26,6 +28,8 @@ const WrapVideo = styled.video`
 export default function MyCamView({
   name, status, mediaBlobUrl, peers,
 }) {
+  useEffect(() => () => cleanUpStream(mediaBlobUrl.current.srcObject), []);
+
   return (
     <Wrapper peers={peers}>
       {name ? <M.NameLabel name={name} /> : <></>}

--- a/src/utils/snippet.js
+++ b/src/utils/snippet.js
@@ -11,3 +11,5 @@ export const sortObjectByOrder = (object) => object.sort((a, b) => {
   }
   return 0;
 });
+
+export const cleanUpStream = (stream) => stream.getTracks().forEach((track) => track.stop());


### PR DESCRIPTION
> resolve #62

## Detail & Solution
혼자연습 혹은 면접 스터디의 카메라의 stream을 가져오는 페이지에 접근 후 사용하지 않는 화면에서도 아래와 같이 사용 중이라고 표시되는 문제를 해결해야 합니다.
<img width="1543" alt="Screen Shot 2021-04-24 at 7 38 51 PM" src="https://user-images.githubusercontent.com/16266103/115955947-ceb84f80-a534-11eb-9dca-39a96cead418.png">

## What I did
Web API인 getUserMedia로 스트림을 가져오는 모든 위치에 아래와 같은 처리를 하였습니다.

- stream을 stop하는 cleanUpStream 유틸 함수 제작하였습니다.
- useEffect로 언마운트 시점에 cleanUpStream을 호출하여 스트림을 멈출 수 있도록 하였습니다.

## What I need to do

