### PR TITLE
sub-header 컴포넌트를 작성한다

### DIFF
--- a/src/components/atoms/SubHeader/SubHeader.js
+++ b/src/components/atoms/SubHeader/SubHeader.js
@@ -1,18 +1,15 @@
-/* eslint-disable indent */
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-const HeaderText = styled.div`
-  font-family: AppleSDGothicNeoB00;
-  font-weight: normal;
-  font-stretch: normal;
-  font-style: normal;
-  font-size: ${({ fontSize }) => fontSize}px;
-  line-height: 1.42;
-  letter-spacing: normal;
-  text-align: left;
-  color: ${({ color }) => color};
+const Container = styled.div`
+  display: inline-block;
+  .header-text {
+    font-family: AppleSDGothicNeoB00;
+    font-size: ${({ fontSize }) => fontSize}px;
+    line-height: 1.42;
+    color: ${({ color }) => color};
+  }
 `;
 
 export default function SubHeader({
@@ -20,11 +17,13 @@ export default function SubHeader({
 }) {
   return (
     <>
-      <HeaderText fontSize={fontSize} color={subTitleColor}>
-        {subHeaderText}
-        &nbsp;
-      </HeaderText>
-      {children}
+      <Container fontSize={fontSize} color={subTitleColor}>
+        <div className="header-text">
+          {subHeaderText}
+          &nbsp;
+        </div>
+        {children}
+      </Container>
     </>
   );
 }

--- a/src/components/atoms/SubHeader/SubHeader.js
+++ b/src/components/atoms/SubHeader/SubHeader.js
@@ -1,0 +1,37 @@
+/* eslint-disable indent */
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const HeaderText = styled.div`
+  font-family: AppleSDGothicNeoB00;
+  font-weight: normal;
+  font-stretch: normal;
+  font-style: normal;
+  font-size: ${({ fontSize }) => fontSize}px;
+  line-height: 1.42;
+  letter-spacing: normal;
+  text-align: left;
+  color: ${({ color }) => color};
+`;
+
+export default function SubHeader({
+  subHeaderText, children, fontSize = 24, subTitleColor = '#6e6eff',
+}) {
+  return (
+    <>
+      <HeaderText fontSize={fontSize} color={subTitleColor}>
+        {subHeaderText}
+        &nbsp;
+      </HeaderText>
+      {children}
+    </>
+  );
+}
+
+SubHeader.propTypes = {
+  subHeaderText: PropTypes.string,
+  children: PropTypes.element.isRequired,
+  fontSize: PropTypes.number,
+  subTitleColor: PropTypes.string,
+};

--- a/src/components/atoms/SubHeader/SubHeader.stories.js
+++ b/src/components/atoms/SubHeader/SubHeader.stories.js
@@ -1,0 +1,19 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+
+import SubHeader from './SubHeader';
+
+export default {
+  title: 'Atoms/SubHeader',
+  component: SubHeader,
+};
+const SubHeaderComponent = (args) => <SubHeader {...args} />;
+
+export const defaultSubHeader = SubHeaderComponent.bind({});
+
+defaultSubHeader.args = {
+  subHeaderText: '서브헤더',
+  children: <span>본문</span>,
+  fontSize: 24,
+  subTitleColor: '#6e6eff',
+};

--- a/src/components/atoms/SubHeader/index.js
+++ b/src/components/atoms/SubHeader/index.js
@@ -1,0 +1,1 @@
+export { default } from './SubHeader';

--- a/src/components/atoms/index.js
+++ b/src/components/atoms/index.js
@@ -6,6 +6,7 @@ import ProfileIcon from './ProfileIcon';
 import QuestionItem from './QuestionItem';
 import TextButton from './TextButton';
 import ToggleButton from './ToggleButton';
+import SubHeader from './SubHeader';
 
 export default {
   Button,
@@ -16,4 +17,5 @@ export default {
   QuestionItem,
   TextButton,
   ToggleButton,
+  SubHeader,
 };


### PR DESCRIPTION
> resolve #70 

## Detail & Solution
* 기획 화면 중, 설명 텍스트 + 컴포넌트 형태가 몇몇 존재합니다.
* 이러한 컴포넌트들의 설명 부분을 공통으로 관리하는 컴포넌트를 구현하였습니다.
* 사용방법
```jsx
<SubHeader
  fontSize={24}
  subHeaderText="서브헤더"
  subTitleColor="#6e6eff"
>
  <span>
    본문
  </span>
</SubHeader>
```


## What I did

![image](https://user-images.githubusercontent.com/28996915/117299503-952c0080-aeb3-11eb-8b8e-4d2140dabf6d.png)
![image](https://user-images.githubusercontent.com/28996915/117299751-da503280-aeb3-11eb-9040-43f6c0de681b.png)

* 위와 같이 **기업 이름/관심 산업_Main** 부분의 텍스트와 특정 컴포넌트가 같이 쓰이는 경우가 존재하여, 텍스트 부분을 공통 컴포넌트로 사용할 수 있도록 구현

## What I need to do

