### PR TITLE
Wrapper 영역을 각 페이지별로 일치될 수 있도록 수정한다

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -88,7 +88,7 @@ export default function App() {
         <Route exact path="/" component={LandingPage} />
         <Route exact path="/login" component={LoginPage} />
         <Route exact path="/sign-up" component={SignUpPage} />
-        <Route exact path="/welcome" componaent={WelcomePage} />
+        <Route exact path="/welcome" component={WelcomePage} />
         {isLoading && (
           <WrapSpinner>
             <SyncLoader size={50} color="#123abc" />

--- a/src/App.js
+++ b/src/App.js
@@ -43,8 +43,27 @@ const WrapPage = styled.div`
   display: flex;
   ${({ toggleTrain }) =>
     toggleTrain
-      ? 'width: 100vw;'
-      : 'height: 100vh; width: calc(100vw - 15.9vh); padding-left: 15.9vh;'}
+      ? `
+        width: 100vw; 
+        height: 100vh;
+        .container {
+          width: 100%;
+        }
+      `
+      : `
+        height: 100vh;
+        width: calc(100vw - 15.9vh);
+        padding-left: 10vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        .container {
+          position: relative;
+          width: 100%;
+          max-width: 160vh;
+          height: 90%;
+        }
+    `}
 `;
 
 const WrapSpinner = styled.div`
@@ -69,7 +88,7 @@ export default function App() {
         <Route exact path="/" component={LandingPage} />
         <Route exact path="/login" component={LoginPage} />
         <Route exact path="/sign-up" component={SignUpPage} />
-        <Route exact path="/welcome" component={WelcomePage} />
+        <Route exact path="/welcome" componaent={WelcomePage} />
         {isLoading && (
           <WrapSpinner>
             <SyncLoader size={50} color="#123abc" />
@@ -78,47 +97,50 @@ export default function App() {
         {ratio < 1.6 && <FragileRatioPage />}
         <Wrapper>
           {!toggleTrain && <O.SideBar />}
-          {!toggleTrain && <O.ProfileMenuContainer name={name} />}
           <WrapPage toggleTrain={toggleTrain}>
-            <R.AuthRoute exact path="/self" component={SelfTrainEntryPage} />
-            <R.AuthRoute
-              exact
-              path="/self/questionlist"
-              component={QuestionListPage}
-            />
-            <R.AuthRoute
-              exact
-              path="/self/question/:id"
-              component={QuestionPage}
-            />
-            <R.AuthRoute
-              exact
-              path="/self/setting/:id"
-              component={SelfTrainSettingPage}
-            />
-            <R.AuthRoute
-              exact
-              path="/self/train/:id"
-              component={SelfTrainPage}
-            />
-            <R.AuthRoute
-              exact
-              path="/self/checklist/:roomId"
-              component={SelfStudyChecklist}
-            />
-            <R.AuthRoute exact path="/replay" component={MyVideoPage} />
-            <R.AuthRoute exact path="/replay/:id" component={VideoPage} />
-            <R.AuthRoute
-              exact
-              path="/peer-study"
-              component={PeerStudyMainPage}
-            />
-            <R.AuthRoute
-              exact
-              path="/peer-study/:id"
-              component={R.PeerStudyRoute}
-            />
-            <R.AuthRoute exact path="/mypage" component={MyPage} />
+            <div className="container">
+              {!toggleTrain && <O.ProfileMenuContainer name={name} />}
+
+              <R.AuthRoute exact path="/self" component={SelfTrainEntryPage} />
+              <R.AuthRoute
+                exact
+                path="/self/questionlist"
+                component={QuestionListPage}
+              />
+              <R.AuthRoute
+                exact
+                path="/self/question/:id"
+                component={QuestionPage}
+              />
+              <R.AuthRoute
+                exact
+                path="/self/setting/:id"
+                component={SelfTrainSettingPage}
+              />
+              <R.AuthRoute
+                exact
+                path="/self/train/:id"
+                component={SelfTrainPage}
+              />
+              <R.AuthRoute
+                exact
+                path="/self/checklist/:roomId"
+                component={SelfStudyChecklist}
+              />
+              <R.AuthRoute exact path="/replay" component={MyVideoPage} />
+              <R.AuthRoute exact path="/replay/:id" component={VideoPage} />
+              <R.AuthRoute
+                exact
+                path="/peer-study"
+                component={PeerStudyMainPage}
+              />
+              <R.AuthRoute
+                exact
+                path="/peer-study/:id"
+                component={R.PeerStudyRoute}
+              />
+              <R.AuthRoute exact path="/mypage" component={MyPage} />
+            </div>
           </WrapPage>
         </Wrapper>
         <R.AuthRoute component={NotFound} />

--- a/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
+++ b/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
@@ -12,8 +12,8 @@ import A from '@atoms';
 
 const Wrapper = styled.div`
   position: absolute;
-  top: 5.3vh;
-  right: 10.5vh;
+  top: 0;
+  right: 0;
   height: 7.3vh;
   display: flex;
   flex-direction: row;

--- a/src/components/organisms/Sidebar/SideBar.js
+++ b/src/components/organisms/Sidebar/SideBar.js
@@ -13,7 +13,6 @@ const Wrapper = styled.div`
   position: fixed;
   width: 10vh;
   min-width: 10vh;
-  max-width: 15.9vh;
   height: 100vh;
   min-height: 20vh;
   border: none;

--- a/src/pages/MyPage/MyPage.style.js
+++ b/src/pages/MyPage/MyPage.style.js
@@ -6,7 +6,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100%;
 `;
 
 const ProfileWrapper = styled.div`

--- a/src/pages/MyVideoPage/MyVideoPage.js
+++ b/src/pages/MyVideoPage/MyVideoPage.js
@@ -22,7 +22,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100%;
 `;
 
 const columns = [

--- a/src/pages/PeerStudyMainPage/PeerStudyMainPage.style.js
+++ b/src/pages/PeerStudyMainPage/PeerStudyMainPage.style.js
@@ -4,8 +4,8 @@ const Wrapper = styled.div`
   display: flex;
   flex: 1;
   flex-direction: column;
-  margin: 5.3vh 0 0 0;
   align-items: center;
+  height: 100%;
 `;
 
 const SearchWrapper = styled.div`

--- a/src/pages/QuestionListPage/QuestionListPage.js
+++ b/src/pages/QuestionListPage/QuestionListPage.js
@@ -15,7 +15,7 @@ const PageWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100%;
 `;
 
 const ContentWrapper = styled.div`

--- a/src/pages/QuestionPage/QuestionPage.js
+++ b/src/pages/QuestionPage/QuestionPage.js
@@ -29,7 +29,7 @@ const PageWrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100%;
 `;
 
 const ContentWrapper = styled.div`

--- a/src/pages/SelfTrainEntryPage/SelfTrainEntryPage.js
+++ b/src/pages/SelfTrainEntryPage/SelfTrainEntryPage.js
@@ -19,7 +19,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100%;
 `;
 
 const WrapContent = styled.div`

--- a/src/pages/SelfTrainPage/SelfTrainPage.style.js
+++ b/src/pages/SelfTrainPage/SelfTrainPage.style.js
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
   background-image: url(${({ source }) => source});
   background-size: cover;
 `;
@@ -49,7 +50,7 @@ const WrapBottomSide = styled.div`
 `;
 
 const WrapText = styled.div`
-  use-select: none;
+  user-select: none;
   padding-right: 2.5vh;
   font-family: AppleSDGothicNeoB00;
   font-size: 1.9vh;

--- a/src/pages/SelfTrainSettingPage/SelfTrainSettingPage.js
+++ b/src/pages/SelfTrainSettingPage/SelfTrainSettingPage.js
@@ -17,7 +17,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  height: 100%;
 `;
 
 const WrapContent = styled.div`


### PR DESCRIPTION
> resolve #74 

## Detail & Solution
로그인 후 사이드바의 각 페이지마다 Wrapper를 일치시킬 필요가 있었습니다. 또한, Profile 컨테이너가 Wraper 영역 밖으로 빠져나가는 문제를 해결해야 했습니다.

## What I did
App.js에 Wrap에 대한 속성을 수정하고 Container 계층을 하나 더 만들어 요구사항을 충족하였습니다.

<img width="1850" alt="Screen Shot 2021-05-12 at 1 33 19 AM" src="https://user-images.githubusercontent.com/16266103/117852168-090a4680-b2c2-11eb-9468-0146a28eb65d.png">
<img width="1850" alt="Screen Shot 2021-05-12 at 1 33 24 AM" src="https://user-images.githubusercontent.com/16266103/117852183-0c9dcd80-b2c2-11eb-852a-01084be9a671.png">
<img width="1850" alt="Screen Shot 2021-05-12 at 1 33 30 AM" src="https://user-images.githubusercontent.com/16266103/117852195-0f98be00-b2c2-11eb-903c-6c92488c69d5.png">
<img width="1850" alt="Screen Shot 2021-05-12 at 1 33 37 AM" src="https://user-images.githubusercontent.com/16266103/117852230-13c4db80-b2c2-11eb-9b90-f2a0ec79e3e1.png">


## What I need to do
- 마이페이지 zeplin 디자인이 변경되었으므로 이를 반영해야 함
- 스크롤이 있는 페이지에서 하단 margin을 어떻게 주어야 할지 생각해야 함
