### PR TITLE
question, questionlist 변경된 구조에 맞춰 엔드포인트를 수정한다 

### DIFF
--- a/src/components/organisms/QuestionCardView/QuestionCardView.js
+++ b/src/components/organisms/QuestionCardView/QuestionCardView.js
@@ -199,7 +199,6 @@ export default function QuestionCardView({
               onClick={(e) => {
                 e.stopPropagation();
                 setSelect(true);
-                console.log('abc');
                 dispatch(displayModal(MODALS.QUESTIONLIST_EDIT_MODAL));
               }}
             >

--- a/src/components/organisms/QuestionCardView/QuestionCardView.js
+++ b/src/components/organisms/QuestionCardView/QuestionCardView.js
@@ -1,9 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { getQuestionItemAPI } from '@repository/questionListRepository';
 import { displayModal } from '@store/Modal/modal';
 import { MODALS } from '@utils/constant';
 import Modal from '@organisms/Modal/Modal';
@@ -151,10 +150,10 @@ export default function QuestionCardView({
   description,
   handleDelete,
   job,
+  length,
 }) {
   const dispatch = useDispatch();
   const [select, setSelect] = useState(false);
-  const [number, setNumber] = useState();
 
   const [isOpen, setIsOpen] = useState(false);
   const history = useHistory();
@@ -164,20 +163,6 @@ export default function QuestionCardView({
   };
 
   const toggle = (set) => setIsOpen(set);
-
-  const fetch = async () => {
-    try {
-      const { data } = await getQuestionItemAPI(id);
-      setNumber(data.length);
-    } catch (error) {
-      console.error(error);
-      alert(error);
-    }
-  };
-
-  useEffect(() => {
-    fetch();
-  }, []);
 
   return (
     <>
@@ -214,6 +199,7 @@ export default function QuestionCardView({
               onClick={(e) => {
                 e.stopPropagation();
                 setSelect(true);
+                console.log('abc');
                 dispatch(displayModal(MODALS.QUESTIONLIST_EDIT_MODAL));
               }}
             >
@@ -223,7 +209,7 @@ export default function QuestionCardView({
         </List>
         <Content>
           <Number>
-            <NumberText>{number}</NumberText>
+            <NumberText>{length}</NumberText>
             <SubText>
               개의 질문이
               <br />
@@ -247,6 +233,7 @@ QuestionCardView.propTypes = {
   description: PropTypes.string.isRequired,
   handleDelete: PropTypes.func,
   job: PropTypes.string.isRequired,
+  length: PropTypes.number.isRequired,
 };
 
 QuestionCardView.defaultProp = {

--- a/src/pages/QuestionListPage/IsQuestionList/IsQuestionList.js
+++ b/src/pages/QuestionListPage/IsQuestionList/IsQuestionList.js
@@ -60,7 +60,7 @@ export default function IsQuestionList({ questionList, handleDelete }) {
             </AddQuestionList>
           </Link>
         </ItemWrapper>
-        {questionList?.map(({ id, title, enterprise, job }, index) => (
+        {questionList?.map(({ id, title, enterprise, job, length }, index) => (
           <ItemWrapper key={`itemQ-${index}`}>
             <O.QuestionCardView
               id={id}
@@ -69,6 +69,7 @@ export default function IsQuestionList({ questionList, handleDelete }) {
               questionList={questionList}
               handleDelete={handleDelete}
               job={job}
+              length={length}
             />
           </ItemWrapper>
         ))}

--- a/src/pages/QuestionPage/QuestionPage.js
+++ b/src/pages/QuestionPage/QuestionPage.js
@@ -8,8 +8,8 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { sortObjectByOrder } from '@utils/snippet';
 import {
-  deleteQuestionItemAPI,
-  getQuestionItemAPI,
+  deleteEachQuestionItemAPI,
+  getEachQuestionItemAPI,
   postQuestionItemAPI,
   patchQuestionItemAPI,
 } from '@repository/questionListRepository';
@@ -133,7 +133,7 @@ export default function QuestionPage({ match }) {
   const fetch = async () => {
     try {
       if (id !== 'new') {
-        const { data } = await getQuestionItemAPI(id);
+        const { data } = await getEachQuestionItemAPI(id);
         setQuestionList(sortObjectByOrder(data));
       }
     } catch (error) {
@@ -151,7 +151,7 @@ export default function QuestionPage({ match }) {
   const handleQuestionMake = async () => {
     try {
       if (deletedItems) {
-        await deletedItems.map((eachId) => deleteQuestionItemAPI(eachId));
+        await deletedItems.map((eachId) => deleteEachQuestionItemAPI(eachId));
       }
 
       const questionListAsc = questionList.map((question, index) => ({

--- a/src/pages/SelfTrainEntryPage/SelfTrainEntryPage.js
+++ b/src/pages/SelfTrainEntryPage/SelfTrainEntryPage.js
@@ -85,7 +85,7 @@ export default function SelfTrainEntryPage({ history }) {
             func={
               // TODO: 기본 질문목록 endpoint 재호님이 추가하면 바꿔야 함
               isGuide
-                ? () => history.push('/self/setting/3')
+                ? () => history.push('/self/setting/basic')
                 : () => history.push('/self/questionlist')
             }
             theme={clicked ? 'blue' : 'gray'}

--- a/src/pages/SelfTrainPage/SelfTrainPage.js
+++ b/src/pages/SelfTrainPage/SelfTrainPage.js
@@ -17,7 +17,7 @@ import {
 } from '@store/Time/time';
 import { setStep, setHistoryId } from '@store/Train/train';
 import { sortObjectByOrder, get } from '@utils/snippet';
-import { getQuestionItemAPI } from '@repository/questionListRepository';
+import { getEachQuestionItemAPI } from '@repository/questionListRepository';
 import { postPreSelfVideoApi } from '@repository/selfHistoryRepository';
 import useReactMediaRecorder from '@hooks/useMediaRecorder';
 
@@ -54,7 +54,7 @@ export default function SelfTrainPage({ match }) {
 
   const fetch = async (requestId) => {
     try {
-      const { data } = await getQuestionItemAPI(requestId);
+      const { data } = await getEachQuestionItemAPI(requestId);
       setQuestionList(sortObjectByOrder(data));
     } catch (error) {
       if (error.response.status === 401) {

--- a/src/pages/SelfTrainSettingPage/SelfTrainSettingPage.js
+++ b/src/pages/SelfTrainSettingPage/SelfTrainSettingPage.js
@@ -87,12 +87,9 @@ export default function SelfTrainSettingPage({ match, history }) {
 
   const fetch = async () => {
     try {
-      const response = await getQuestionListAPI();
-      const exactData = response.data.filter(
-        (each) => each.id === Number(id),
-      )[0];
-      dispatch(setCompany({ company: exactData.title }));
-      dispatch(setJob({ job: exactData.job }));
+      const { data } = await getQuestionListAPI(id);
+      dispatch(setCompany({ company: data.enterprise }));
+      dispatch(setJob({ job: data.job }));
     } catch (error) {
       console.error(error);
       alert(error);

--- a/src/repository/questionListRepository.js
+++ b/src/repository/questionListRepository.js
@@ -27,7 +27,7 @@ export const deleteQuestionListAPI = async (param) =>
     type: 'delete',
   });
 
-export const getQuestionItemAPI = async (param) =>
+export const getEachQuestionItemAPI = async (param) =>
   await api({
     url: `/api/self/question/${param}`,
     type: 'get',
@@ -47,7 +47,7 @@ export const patchQuestionItemAPI = async (param) =>
     param,
   });
 
-export const deleteQuestionItemAPI = async (param) =>
+export const deleteEachQuestionItemAPI = async (param) =>
   await api({
     url: `/api/self/question/${param}`,
     type: 'delete',

--- a/src/repository/questionListRepository.js
+++ b/src/repository/questionListRepository.js
@@ -2,9 +2,8 @@ import api from '@context/serverContext';
 
 export const getQuestionListAPI = async (param) =>
   await api({
-    url: '/api/self/questionList',
+    url: `/api/self/questionList/${param}`,
     type: 'get',
-    param,
   });
 
 export const postQuestionListAPI = async (param) =>

--- a/src/repository/questionListRepository.js
+++ b/src/repository/questionListRepository.js
@@ -2,7 +2,7 @@ import api from '@context/serverContext';
 
 export const getQuestionListAPI = async (param) =>
   await api({
-    url: `/api/self/questionList/${param}`,
+    url: `/api/self/questionList/${param || ''}`,
     type: 'get',
   });
 
@@ -23,7 +23,7 @@ export const patchQuestionListAPI = async (param) =>
 
 export const deleteQuestionListAPI = async (param) =>
   await api({
-    url: `/api/self/questionList/${param}`,
+    url: `/api/self/questionList/${param || ''}`,
     type: 'delete',
   });
 


### PR DESCRIPTION
> resolve #82 

## Detail & Solution
회원마다 기본 질문리스트 id가 달라지는 이슈가 있어서 이를 반환하는 엔드포인트를 요청하였습니다. 서버측에서 구조적으로 리팩토링해야 할 지점이 있어 이부분에 대한 수정이 이루어질 가능성이 커졌습니다. 이를 반영합니다.

## What I did
- [x] 세팅화면에 기존 filter로 처리하던 부분을 엔드포인트에 리퀘스트 파람으로 특정해서 가져올 수 있도록 변경하였습니다. cdf6bc1
- [x] 기존 질문 갯수에 대해 getQuestionItemAPI를 찔러서 갯수를 확인하게끔 되어있는 부분을 getQuestionListAPI의 필드에 length를 추가해서 해결하게끔 변경되어 해당 부분을 리팩토링 했습니다. 2c2aced


## What I need to do

