### PR TITLE
sockjs 연결 URL을 http 에서 https로 변경한다

### DIFF
--- a/src/hooks/useSockStomp.js
+++ b/src/hooks/useSockStomp.js
@@ -4,7 +4,7 @@ import Stomp from 'stompjs';
 import moment from 'moment';
 
 export default function useSockStomp({
-  url = 'http://api.witherview.com/socket',
+  url = 'https://api.witherview.com/socket',
   roomId,
 }) {
   const [roomChat, setRoomChat] = useState([]);


### PR DESCRIPTION
> resolve #<Issue Number>

## Detail & Solution
witherview.com 에서 sock.js 연결시 http 연결은 불가하다는 오류가 발생해서 해당 URL을 https로 변경해야 했습니다.

## What I did
http를 https로 변경하였습니다.

## What I need to do

