### PR TITLE
로그인한 상태에서 랜딩 페이지 헤더에 사용자 정보가 나타나도록 한다

### DIFF
--- a/src/components/atoms/ProfileIcon/ProfileIcon.js
+++ b/src/components/atoms/ProfileIcon/ProfileIcon.js
@@ -7,10 +7,20 @@ import { get } from '@utils/snippet';
 import profileDefault from '@assets/images/profile_default.png';
 
 const Wrapper = styled.div`
-  width: ${({ isSmall }) => (isSmall ? 6 : 7.3)}vh;
-  height: ${({ isSmall }) => (isSmall ? 6 : 7.3)}vh;
-  border-radius: ${({ isSmall }) => (isSmall ? 1 : 2)}vh;
-  box-shadow: 0 0.6vh 1.2vh 0 rgba(0, 0, 0, 0.04);
+  ${({ isPx, isSmall }) =>
+    isPx
+      ? `
+    width: ${isSmall ? 60 : 73}px;
+    height: ${isSmall ? 60 : 73}px;
+    border-radius: ${isSmall ? 10 : 20}px;
+    box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.04);
+  `
+      : `
+    width: ${isSmall ? 6 : 7.3}vh;
+    height: ${isSmall ? 6 : 7.3}vh;
+    border-radius: ${isSmall ? 1 : 2}vh;
+    box-shadow: 0 0.6vh 1.2vh 0 rgba(0, 0, 0, 0.04);
+  `}
   user-select: none;
   background-image: url(${({ src }) => src});
   background-position: center center;
@@ -18,13 +28,14 @@ const Wrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.lightGrey};
 `;
 
-export default function ProfileIcon({ src, isSmall }) {
+export default function ProfileIcon({ src, isSmall, isPx }) {
   const { profileImg } = useSelector(get('auth'));
   return (
     <Wrapper
       src={src || profileImg || profileDefault}
       isSmall={isSmall}
       alt="profile_image"
+      isPx={isPx}
     />
   );
 }
@@ -32,6 +43,7 @@ export default function ProfileIcon({ src, isSmall }) {
 ProfileIcon.propTypes = {
   src: PropTypes.string,
   isSmall: PropTypes.bool,
+  isPx: PropTypes.bool,
 };
 
 ProfileIcon.defaultProps = {

--- a/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
+++ b/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
@@ -1,3 +1,6 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 import React, { useState } from 'react';
 
 import PropTypes from 'prop-types';
@@ -18,73 +21,73 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-`;
 
-const WrapMenu = styled.div`
-  list-style-type: none;
-  position: relative;
-  text-align: center;
-  z-index: 101;
-  ${({ isOpen }) =>
-    isOpen &&
-    `
+  div.wrap-menu {
+    list-style-type: none;
+    position: relative;
+    text-align: center;
+    z-index: 101;
+    ${({ isOpen }) =>
+      isOpen &&
+      `
     fill: #0b3895;
     transform: scale(1);
   `}
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-`;
-
-const Name = styled.div`
-  font-family: AppleSDGothicNeoEB00;
-  font-size: 1.5vh;
-  padding-left: ${({ isSmall }) => (isSmall ? '1.5vh' : '2.9vh')};
-  padding-right: 1vh;
-  user-select: none;
-  color: #3d3d3d;
-`;
-
-const List = styled.ul`
-  width: 14.3vh;
-  padding: 1.85vh 0vh 1.85vh 0vh;
-  position: absolute;
-  top: 7vh;
-  right: 0;
-  z-index: 101;
-  background-color: #fff;
-  transition: 0.25s ease all;
-  transform: scale(0);
-  transform-origin: 0 1;
-  border-radius: 1vh;
-  box-shadow: 0 1.2vh 2.4vh 0 rgba(4, 4, 161, 0.15);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-
-  transform: ${({ isOpen }) => isOpen && 'scale(1)'};
-`;
-
-const Item = styled.li`
-  width: 8.7vh;
-  padding-top: 1.25vh;
-  padding-bottom: 1.25vh;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-`;
-
-const Each = styled.div`
-  user-select: none;
-  font-family: AppleSDGothicNeoM00;
-  font-size: 1.5vh;
-  color: #9e9e9e;
-  &:hover {
-    color: #f2886b;
-    text-decoration: none;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
   }
-  cursor: pointer;
+
+  div.name {
+    font-family: AppleSDGothicNeoEB00;
+    font-size: 1.5vh;
+    padding-left: ${({ isSmall }) => (isSmall ? '1.5vh' : '2.9vh')};
+    padding-right: 1vh;
+    user-select: none;
+    color: #3d3d3d;
+  }
+
+  ul.list {
+    width: 14.3vh;
+    padding: 1.85vh 0vh 1.85vh 0vh;
+    position: absolute;
+    top: 7vh;
+    right: 0;
+    z-index: 101;
+    background-color: #fff;
+    transition: 0.25s ease all;
+    transform: scale(0);
+    transform-origin: 0 1;
+    border-radius: 1vh;
+    box-shadow: 0 1.2vh 2.4vh 0 rgba(4, 4, 161, 0.15);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+
+    transform: ${({ isOpen }) => isOpen && 'scale(1)'};
+  }
+
+  li.item {
+    width: 8.7vh;
+    padding-top: 1.25vh;
+    padding-bottom: 1.25vh;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  div.each {
+    user-select: none;
+    font-family: AppleSDGothicNeoM00;
+    font-size: 1.5vh;
+    color: #9e9e9e;
+    &:hover {
+      color: #f2886b;
+      text-decoration: none;
+    }
+    cursor: pointer;
+  }
 `;
 
 export default function ProfileMenuContainer({
@@ -100,32 +103,35 @@ export default function ProfileMenuContainer({
   const toggle = (set) => setIsOpen(set);
 
   return (
-    <Wrapper isAbsolute={isAbsolute}>
-      <WrapMenu
-        isOpen={isOpen}
+    <Wrapper isAbsolute={isAbsolute} isOpen={isOpen} isSmall={isSmall}>
+      <div
+        className="wrap-menu"
         onMouseOver={() => toggle(true)}
         onMouseLeave={() => toggle(false)}
       >
         <A.ProfileIcon src={src} isSmall={isSmall} />
-        <Name isSmall={isSmall}>{name || 'Unknown'}</Name>
+        <div className="name">{name || 'Unknown'}</div>
 
         <A.Icon type="arrow_down_grey" alt="arrow_down_grey" />
-        <List isOpen={isOpen}>
-          <Item>
-            <Each onClick={() => history.push('/mypage')}>마이페이지</Each>
-          </Item>
-          <Item>
-            <Each
+        <ul className="list">
+          <li className="item">
+            <div className="each" onClick={() => history.push('/mypage')}>
+              마이페이지
+            </div>
+          </li>
+          <li className="item">
+            <div
+              className="each"
               onClick={() => {
                 dispatch(setLogout());
                 history.push('/');
               }}
             >
               로그아웃
-            </Each>
-          </Item>
-        </List>
-      </WrapMenu>
+            </div>
+          </li>
+        </ul>
+      </div>
     </Wrapper>
   );
 }

--- a/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
+++ b/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
@@ -11,7 +11,7 @@ import { setLogout } from '@store/Auth/auth';
 import A from '@atoms';
 
 const Wrapper = styled.div`
-  position: absolute;
+  position: ${({ isAbsolute }) => isAbsolute && 'absolute'};
   top: 0;
   right: 0;
   height: 7.3vh;
@@ -39,7 +39,7 @@ const WrapMenu = styled.div`
 const Name = styled.div`
   font-family: AppleSDGothicNeoEB00;
   font-size: 1.5vh;
-  padding-left: 2.9vh;
+  padding-left: ${({ isSmall }) => (isSmall ? '1.5vh' : '2.9vh')};
   padding-right: 1vh;
   user-select: none;
   color: #3d3d3d;
@@ -87,7 +87,12 @@ const Each = styled.div`
   cursor: pointer;
 `;
 
-export default function ProfileMenuContainer({ name, src }) {
+export default function ProfileMenuContainer({
+  name,
+  src,
+  isSmall = false,
+  isAbsolute = true,
+}) {
   const history = useHistory();
   const dispatch = useDispatch();
 
@@ -95,14 +100,14 @@ export default function ProfileMenuContainer({ name, src }) {
   const toggle = (set) => setIsOpen(set);
 
   return (
-    <Wrapper>
+    <Wrapper isAbsolute={isAbsolute}>
       <WrapMenu
         isOpen={isOpen}
         onMouseOver={() => toggle(true)}
         onMouseLeave={() => toggle(false)}
       >
-        <A.ProfileIcon src={src} />
-        <Name>{name || 'Unknown'}</Name>
+        <A.ProfileIcon src={src} isSmall={isSmall} />
+        <Name isSmall={isSmall}>{name || 'Unknown'}</Name>
 
         <A.Icon type="arrow_down_grey" alt="arrow_down_grey" />
         <List isOpen={isOpen}>
@@ -128,8 +133,12 @@ export default function ProfileMenuContainer({ name, src }) {
 ProfileMenuContainer.propTypes = {
   name: PropTypes.string,
   src: PropTypes.string,
+  isSmall: PropTypes.bool,
+  isAbsolute: PropTypes.bool,
 };
 
 ProfileMenuContainer.defaultProps = {
   name: '홍길동',
+  isSmall: false,
+  isAbsolute: true,
 };

--- a/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
+++ b/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
@@ -17,7 +17,7 @@ const Wrapper = styled.div`
   position: ${({ isAbsolute }) => isAbsolute && 'absolute'};
   top: 0;
   right: 0;
-  height: 7.3vh;
+  height: ${({ usePx }) => (usePx ? '73px' : '7.3vh')};
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -40,26 +40,28 @@ const Wrapper = styled.div`
 
   div.name {
     font-family: AppleSDGothicNeoEB00;
-    font-size: 1.5vh;
-    padding-left: ${({ isSmall }) => (isSmall ? '1.5vh' : '2.9vh')};
-    padding-right: 1vh;
+    font-size: ${({ usePx }) => (usePx ? '15px' : '1.5vh')};
+    padding-left: ${({ isSmall, usePx }) =>
+      isSmall ? (usePx ? '15px' : '1.5vh') : usePx ? '29px' : '2.9vh'};
+    padding-right: ${({ usePx }) => (usePx ? '10px' : '1vh')};
     user-select: none;
     color: #3d3d3d;
   }
 
   ul.list {
-    width: 14.3vh;
-    padding: 1.85vh 0vh 1.85vh 0vh;
+    width: ${({ usePx }) => (usePx ? '143px' : '14.3vh')};
+    padding: ${({ usePx }) => (usePx ? '18.5px 0px' : '1.85vh 0vh')};
     position: absolute;
-    top: 7vh;
+    top: ${({ usePx }) => (usePx ? '70px' : '7vh')};
     right: 0;
     z-index: 101;
     background-color: #fff;
     transition: 0.25s ease all;
     transform: scale(0);
     transform-origin: 0 1;
-    border-radius: 1vh;
-    box-shadow: 0 1.2vh 2.4vh 0 rgba(4, 4, 161, 0.15);
+    border-radius: ${({ usePx }) => (usePx ? '10px' : '1vh')};
+    box-shadow: ${({ usePx }) =>
+      `${usePx ? '0 12px 24px 0' : '0 1.2vh 2.4vh 0'} rgba(4, 4, 161, 0.15)`};
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -69,9 +71,9 @@ const Wrapper = styled.div`
   }
 
   li.item {
-    width: 8.7vh;
-    padding-top: 1.25vh;
-    padding-bottom: 1.25vh;
+    width: ${({ usePx }) => (usePx ? '87px' : '8.7vh')};
+    padding-top: ${({ usePx }) => (usePx ? '12.5px' : '1.25vh')};
+    padding-bottom: ${({ usePx }) => (usePx ? '12.5px' : '1.25vh')};
     display: flex;
     align-items: center;
     justify-content: flex-start;
@@ -80,7 +82,7 @@ const Wrapper = styled.div`
   div.each {
     user-select: none;
     font-family: AppleSDGothicNeoM00;
-    font-size: 1.5vh;
+    font-size: ${({ usePx }) => (usePx ? '15px' : '1.5vh')};
     color: #9e9e9e;
     &:hover {
       color: #f2886b;
@@ -95,6 +97,7 @@ export default function ProfileMenuContainer({
   src,
   isSmall = false,
   isAbsolute = true,
+  usePx = false,
 }) {
   const history = useHistory();
   const dispatch = useDispatch();
@@ -103,7 +106,12 @@ export default function ProfileMenuContainer({
   const toggle = (set) => setIsOpen(set);
 
   return (
-    <Wrapper isAbsolute={isAbsolute} isOpen={isOpen} isSmall={isSmall}>
+    <Wrapper
+      isAbsolute={isAbsolute}
+      isOpen={isOpen}
+      isSmall={isSmall}
+      usePx={usePx}
+    >
       <div
         className="wrap-menu"
         onMouseOver={() => toggle(true)}
@@ -141,10 +149,11 @@ ProfileMenuContainer.propTypes = {
   src: PropTypes.string,
   isSmall: PropTypes.bool,
   isAbsolute: PropTypes.bool,
+  usePx: PropTypes.bool,
 };
 
 ProfileMenuContainer.defaultProps = {
   name: '홍길동',
   isSmall: false,
-  isAbsolute: true,
+  usePx: false,
 };

--- a/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
+++ b/src/components/organisms/ProfileMenuContainer/ProfileMenuContainer.js
@@ -30,12 +30,31 @@ const Wrapper = styled.div`
     ${({ isOpen }) =>
       isOpen &&
       `
-    fill: #0b3895;
-    transform: scale(1);
-  `}
+        fill: #0b3895;
+        transform: scale(1);
+      `}
     display: flex;
     flex-direction: row;
     align-items: center;
+    ${({ usePx }) =>
+      usePx &&
+      `
+       > div:nth-child(1) {
+          width: 45px;
+          height: 45px;
+        }
+        > i {
+          margin: 2px;
+          background-size: 1237px 876px;
+          background-position: -400.5px -45px;
+          width: 14px;
+          height: 14px;
+        }
+        > ul {
+          top: 40px;
+          right: -20px;
+        }
+    `};
   }
 
   div.name {
@@ -117,7 +136,7 @@ export default function ProfileMenuContainer({
         onMouseOver={() => toggle(true)}
         onMouseLeave={() => toggle(false)}
       >
-        <A.ProfileIcon src={src} isSmall={isSmall} />
+        <A.ProfileIcon src={src} isSmall={isSmall} isPx={usePx} />
         <div className="name">{name || 'Unknown'}</div>
 
         <A.Icon type="arrow_down_grey" alt="arrow_down_grey" />

--- a/src/pages/LandingPage/LandingHeader.js
+++ b/src/pages/LandingPage/LandingHeader.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 
 import A from '@atoms';
+import O from '@organisms';
 import Logo from '@assets/images/witherview_logo_title_dark.png';
 import TextButtonProps from './components/TextButtonProps';
 
@@ -80,7 +81,8 @@ export default function LandingHeader({
 }) {
   const history = useHistory();
   const executeScroll = (ref) => scrollToRef(ref);
-
+  const isLoggedIn = sessionStorage.getItem('isLogin') !== null;
+  const name = sessionStorage.getItem('name');
   return (
     <Wrapper>
       <div className="wrap-container">
@@ -102,13 +104,17 @@ export default function LandingHeader({
             />
           </div>
           <div className="wrap-button">
-            <A.Button
-              id="menu_btn"
-              theme="outline"
-              width={140}
-              text="LOG IN"
-              func={() => history.push('/login')}
-            />
+            {isLoggedIn ? (
+              <O.ProfileMenuContainer name={name} />
+            ) : (
+              <A.Button
+                id="menu_btn"
+                theme="outline"
+                width={140}
+                text="LOG IN"
+                func={() => history.push('/login')}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/LandingPage/LandingHeader.js
+++ b/src/pages/LandingPage/LandingHeader.js
@@ -109,7 +109,12 @@ export default function LandingHeader({
           </div>
           {isLoggedIn ? (
             <div className="wrap-profile">
-              <O.ProfileMenuContainer name={name} isSmall isAbsolute={false} />
+              <O.ProfileMenuContainer
+                name={name}
+                isSmall
+                isAbsolute={false}
+                usePx
+              />
             </div>
           ) : (
             <div className="wrap-button">

--- a/src/pages/LandingPage/LandingHeader.js
+++ b/src/pages/LandingPage/LandingHeader.js
@@ -21,47 +21,46 @@ const Wrapper = styled.div`
   -moz-box-shadow: 0px -5px 44px -2px rgba(4, 4, 161, 0.27);
   box-shadow: 0px -5px 44px -2px rgba(4, 4, 161, 0.27);
   background-color: white;
-`;
 
-const WrapLeft = styled.img`
-  width: 120px;
-`;
-
-const WrapContainer = styled.div`
-  width: 90%;
-  max-width: 1150px;
-  min-width: 90%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-`;
-
-const WrapTextButton = styled.div`
-  @media only screen and (max-width: 1150px) {
-    display: none;
+  img.wrap-left {
+    width: 120px;
   }
-  min-width: 350px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding-right: 60px;
-`;
+  div.wrap-container {
+    width: 90%;
+    max-width: 1150px;
+    min-width: 90%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
 
-const WrapRightInner = styled.div`
-  width: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-`;
+  div.wrap-text-button {
+    @media only screen and (max-width: 1150px) {
+      display: none;
+    }
+    min-width: 350px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-right: 60px;
+  }
 
-const WrapButton = styled.div`
-  > div {
-    height: 35px;
-    border-radius: 5px;
-    border-width: 1.5px;
-    > p {
-      font-size: 12px;
-      font-family: AppleSDGothicNeoEB00;
+  div.wrap-right-inner {
+    width: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  div.wrap-button {
+    > div {
+      height: 35px;
+      border-radius: 5px;
+      border-width: 1.5px;
+      > p {
+        font-size: 12px;
+        font-family: AppleSDGothicNeoEB00;
+      }
     }
   }
 `;
@@ -84,10 +83,10 @@ export default function LandingHeader({
 
   return (
     <Wrapper>
-      <WrapContainer>
-        <WrapLeft src={Logo} />
-        <WrapRightInner>
-          <WrapTextButton>
+      <div className="wrap-container">
+        <img className="wrap-left" src={Logo} alt="witherview" />
+        <div className="wrap-right-inner">
+          <div className="wrap-text-button">
             <TextButtonProps onClick={() => executeScroll(topRef)} text="홈" />
             <TextButtonProps
               onClick={() => executeScroll(middleOneRef)}
@@ -101,8 +100,8 @@ export default function LandingHeader({
               onClick={() => executeScroll(studyRef)}
               text="면접스터디"
             />
-          </WrapTextButton>
-          <WrapButton>
+          </div>
+          <div className="wrap-button">
             <A.Button
               id="menu_btn"
               theme="outline"
@@ -110,9 +109,9 @@ export default function LandingHeader({
               text="LOG IN"
               func={() => history.push('/login')}
             />
-          </WrapButton>
-        </WrapRightInner>
-      </WrapContainer>
+          </div>
+        </div>
+      </div>
     </Wrapper>
   );
 }

--- a/src/pages/LandingPage/LandingHeader.js
+++ b/src/pages/LandingPage/LandingHeader.js
@@ -53,6 +53,10 @@ const Wrapper = styled.div`
     justify-content: flex-end;
   }
 
+  div.wrap-profile {
+    width: 143px; //button width 140px + border width 1.5px * 2
+  }
+
   div.wrap-button {
     > div {
       height: 35px;
@@ -103,10 +107,12 @@ export default function LandingHeader({
               text="면접스터디"
             />
           </div>
-          <div className="wrap-button">
-            {isLoggedIn ? (
-              <O.ProfileMenuContainer name={name} />
-            ) : (
+          {isLoggedIn ? (
+            <div className="wrap-profile">
+              <O.ProfileMenuContainer name={name} isSmall isAbsolute={false} />
+            </div>
+          ) : (
+            <div className="wrap-button">
               <A.Button
                 id="menu_btn"
                 theme="outline"
@@ -114,8 +120,8 @@ export default function LandingHeader({
                 text="LOG IN"
                 func={() => history.push('/login')}
               />
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
     </Wrapper>

--- a/src/store/Auth/auth.js
+++ b/src/store/Auth/auth.js
@@ -30,6 +30,7 @@ const authReducer = createSlice({
         },
       },
     ) {
+      sessionStorage.setItem('isLogin', true);
       sessionStorage.setItem('name', name);
       sessionStorage.setItem('email', email);
       sessionStorage.setItem('profileImg', profileImg);
@@ -52,6 +53,7 @@ const authReducer = createSlice({
       };
     },
     setLogout(state) {
+      sessionStorage.removeItem('isLogin');
       sessionStorage.removeItem('accessToken');
       sessionStorage.removeItem('name');
       sessionStorage.removeItem('email');


### PR DESCRIPTION
> resolve #104 

## Detail & Solution
- 기존 파일 style을 새롭게 정한 코드 컨벤션에 맞춰서 리팩토링 `a97429a`
- 로그인 여부를 나타내는 정보를 Session storage에 저장하여 메인페이지에 로그인 여부에 따라 버튼이 변경되도록 함 `edc60f9`
- 프로필 메뉴 컨테이너의 Props를 수정하여 사이즈 설정에 따라 랜딩 헤더에 맞도록 함 `a210a29`
## What I did
<img width="569" alt="Screen Shot 2021-06-20 at 7 51 52 PM" src="https://user-images.githubusercontent.com/40855076/122671383-3fac7880-d201-11eb-9daa-80c28d8414d5.png">

## What I need to do  

`질문사항`
- isLogIn 정보를 아래와 같이 Session storage에 저장하고 삭제하는 방식이 바람직한지..? 더 나은 방법이 있다면 말씀해주세요!
```js
sessionStorage.setItem('isLogin', true);
sessionStorage.removeItem('isLogin');
```
- 현재 랜딩헤더의 프로필 이미지가 isSmall로 설정해도 헤더 높이 대비 크기가 커보임.. => 은비님께 확인 후 필요하면 추가수정할게요
- ProfileMenuContainer에 props를 추가해서 스타일을 맞추는 식으로 변경했는데 혹시 개선될 수 있는 방향이 있는지 궁금합니다 ㅎㅎ