### PR TITLE
회원 탈퇴 기능을 구현한다

### DIFF
--- a/src/components/organisms/Modal/Modal.js
+++ b/src/components/organisms/Modal/Modal.js
@@ -9,6 +9,7 @@ import StudyMakeModal from './StudyMakeModal';
 import EvaluationModal from './EvaluationModal';
 import QuestionListEditModal from './QuestionListEditModal';
 import IndustrySelectModal from './IndustrySelectModal';
+import WithdrawConfirmModal from './WithdrawConfirmModal';
 
 export default function Modal({
   modalName,
@@ -29,6 +30,7 @@ export default function Modal({
     [MODALS.INDUSTRY_SELECT_MODAL]: (
       <IndustrySelectModal func={func} initialIndustries={initialIndustries} />
     ),
+    [MODALS.WITHDRAW_CONFIRM_MODAL]: <WithdrawConfirmModal />,
   };
   return (
     <>

--- a/src/components/organisms/Modal/WithdrawConfirmModal/WithdrawConfirmModal.js
+++ b/src/components/organisms/Modal/WithdrawConfirmModal/WithdrawConfirmModal.js
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
+import { withdrawApi } from '@repository/accountRepository';
+import A from '@atoms';
+import { removeModal } from '@store/Modal/modal';
+import { MODALS } from '@utils/constant';
+import { setLogout } from '@store/Auth/auth';
+import { useHistory } from 'react-router-dom';
+
+const WithdrawModal = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 71.8vh;
+  height: 50vh;
+
+  .close {
+    align-self: flex-end;
+    margin: 2.6vh 2.6vh 1.1vh 0;
+    > i {
+      cursor: pointer;
+    }
+  }
+
+  .title {
+    margin-top: 2.5vh;
+    font-family: AppleSDGothicNeoEB00;
+    font-size: 3.6vh;
+    font-weight: normal;
+    font-stretch: normal;
+    font-style: bold;
+    line-height: 1.44;
+    letter-spacing: normal;
+    text-align: left;
+    color: #000000;
+  }
+
+  .content {
+    margin: 2vh 0 3.8vh 0;
+    font-family: AppleSDGothicNeoM00;
+    font-size: 2.4vh;
+    font-weight: normal;
+    font-stretch: normal;
+    font-style: normal;
+    line-height: 1.33;
+    letter-spacing: normal;
+    text-align: left;
+    color: #3d3d3d;
+  }
+
+  .password-field {
+    display: flex;
+
+    > div {
+      margin: 0 2vh 2.8vh 2vh;
+
+      input {
+        height: inherit;
+        font-size: 1.8vh;
+      }
+    }
+  }
+
+  .button-wrapper {
+    ${({ theme }) => theme.button}
+  }
+`;
+
+export default function WithdrawConfirmModal() {
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const [password, setPassword] = useState();
+  const [confirmPassword, setConfirmPassword] = useState();
+
+  const handleHideModal = () => {
+    dispatch(removeModal({ modalName: MODALS.WITHDRAW_CONFIRM_MODAL }));
+  };
+
+  const handleStart = async () => {
+    if (password !== confirmPassword) {
+      alert('비밀번호가 같지 않습니다.');
+      return;
+    }
+
+    try {
+      const result = await withdrawApi({
+        password,
+      });
+
+      if (result.status !== 200) alert(result.response.data.message);
+      else {
+        dispatch(removeModal({ modalName: MODALS.WITHDRAW_CONFIRM_MODAL }));
+        dispatch(setLogout());
+        history.push('/');
+        alert(result.data);
+      }
+    } catch (e) {
+      alert(e.response.data.message);
+    }
+  };
+
+  return (
+    <>
+      <WithdrawModal>
+        <div className="close">
+          <A.Icon type="cancel_blue" alt="" func={handleHideModal} />
+        </div>
+        <A.Icon type="check_large" alt="" />
+        <div className="title">정말 탈퇴하시겠습니까?</div>
+        <div className="content">
+          탈퇴할 경우 계정 재사용 및 복구가 불가능합니다.
+        </div>
+        <div className="password-field">
+          <A.SubHeader subHeaderText="새 비밀번호" fontSize="2vh">
+            <A.InputBar
+              value={password}
+              isFullWidth
+              type="password"
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </A.SubHeader>
+          <A.SubHeader subHeaderText="새 비밀번호 확인" fontSize="2vh">
+            <A.InputBar
+              value={confirmPassword}
+              isFullWidth
+              type="password"
+              onChange={(e) => setConfirmPassword(e.target.value)}
+            />
+          </A.SubHeader>
+        </div>
+        <div className="button-wrapper">
+          <A.Button
+            text="탈퇴하기"
+            theme="blue"
+            func={async () => await handleStart()}
+          />
+        </div>
+      </WithdrawModal>
+    </>
+  );
+}

--- a/src/components/organisms/Modal/WithdrawConfirmModal/WithdrawConfirmModal.js
+++ b/src/components/organisms/Modal/WithdrawConfirmModal/WithdrawConfirmModal.js
@@ -112,7 +112,7 @@ export default function WithdrawConfirmModal() {
           탈퇴할 경우 계정 재사용 및 복구가 불가능합니다.
         </div>
         <div className="password-field">
-          <A.SubHeader subHeaderText="새 비밀번호" fontSize="2vh">
+          <A.SubHeader subHeaderText="비밀번호" fontSize="2vh">
             <A.InputBar
               value={password}
               isFullWidth
@@ -120,7 +120,7 @@ export default function WithdrawConfirmModal() {
               onChange={(e) => setPassword(e.target.value)}
             />
           </A.SubHeader>
-          <A.SubHeader subHeaderText="새 비밀번호 확인" fontSize="2vh">
+          <A.SubHeader subHeaderText="비밀번호 확인" fontSize="2vh">
             <A.InputBar
               value={confirmPassword}
               isFullWidth

--- a/src/components/organisms/Modal/WithdrawConfirmModal/index.js
+++ b/src/components/organisms/Modal/WithdrawConfirmModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './WithdrawConfirmModal';

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -57,10 +57,6 @@ export default function MyPage() {
     }
   };
 
-  const openWithdrawConfirmModal = () => {
-    dispatch(displayModal({ modalName: MODALS.WITHDRAW_CONFIRM_MODAL }));
-  };
-
   useEffect(() => {
     (async () => {
       try {
@@ -192,7 +188,11 @@ export default function MyPage() {
           text="저장"
           func={async () => await updateUserInfo()}
         />
-        <S.WithdrawWrapper onClick={() => openWithdrawConfirmModal()}>
+        <S.WithdrawWrapper
+          onClick={() =>
+            dispatch(displayModal({ modalName: MODALS.WITHDRAW_CONFIRM_MODAL }))
+          }
+        >
           회원 탈퇴 {'>'}
         </S.WithdrawWrapper>
       </S.ButtonWrapper>

--- a/src/pages/MyPage/MyPage.js
+++ b/src/pages/MyPage/MyPage.js
@@ -1,18 +1,22 @@
 import React, { useState, useEffect } from 'react';
 
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import A from '@atoms';
 import M from '@molecules';
+import O from '@organisms';
 
 import {
   getUserStatisticsApi,
   putProfileInfoApi,
 } from '@repository/accountRepository';
 import { get } from '@utils/snippet';
+import { displayModal } from '@store/Modal/modal';
+import { MODALS } from '@utils/constant';
 import S from './MyPage.style';
 import Box from './Box';
 
 export default function MyPage() {
+  const dispatch = useDispatch();
   const {
     name,
     email,
@@ -51,6 +55,10 @@ export default function MyPage() {
       console.error(error);
       alert(error);
     }
+  };
+
+  const openWithdrawConfirmModal = () => {
+    dispatch(displayModal({ modalName: MODALS.WITHDRAW_CONFIRM_MODAL }));
   };
 
   useEffect(() => {
@@ -115,6 +123,7 @@ export default function MyPage() {
 
   return (
     <S.Wrapper>
+      <O.Modal modalName={MODALS.WITHDRAW_CONFIRM_MODAL} />
       <S.ProfileWrapper>
         <S.Profile>
           <M.ProfileEdit />
@@ -183,6 +192,9 @@ export default function MyPage() {
           text="저장"
           func={async () => await updateUserInfo()}
         />
+        <S.WithdrawWrapper onClick={() => openWithdrawConfirmModal()}>
+          회원 탈퇴 {'>'}
+        </S.WithdrawWrapper>
       </S.ButtonWrapper>
     </S.Wrapper>
   );

--- a/src/pages/MyPage/MyPage.style.js
+++ b/src/pages/MyPage/MyPage.style.js
@@ -196,6 +196,9 @@ const BoxWrapper = styled.div`
 `;
 
 const ButtonWrapper = styled.div`
+  width: 100%;
+  position: relative;
+  text-align: -webkit-center;
   ${({ theme }) => theme.button}
 `;
 
@@ -210,6 +213,16 @@ const InputWrapper = styled.div`
       background-color: white;
     }
   }
+`;
+
+const WithdrawWrapper = styled.span`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  font-size: 2.1vh;
+  font-family: AppleSDGothicNeoM00;
+  color: #3d3d3d;
+  cursor: pointer;
 `;
 
 export default {
@@ -233,4 +246,5 @@ export default {
   BlockItem,
   ButtonWrapper,
   InputWrapper,
+  WithdrawWrapper,
 };

--- a/src/pages/MyPage/MyPage.style.js
+++ b/src/pages/MyPage/MyPage.style.js
@@ -196,9 +196,10 @@ const BoxWrapper = styled.div`
 `;
 
 const ButtonWrapper = styled.div`
+  display: flex;
   width: 100%;
   position: relative;
-  text-align: -webkit-center;
+  justify-content: center;
   ${({ theme }) => theme.button}
 `;
 

--- a/src/repository/accountRepository.js
+++ b/src/repository/accountRepository.js
@@ -49,3 +49,10 @@ export const registerApi = async (param) =>
     type: 'post',
     param,
   });
+
+export const withdrawApi = async (param) =>
+  await api({
+    url: '/withdraw',
+    type: 'delete',
+    param,
+  });

--- a/src/store/Modal/modal.js
+++ b/src/store/Modal/modal.js
@@ -10,6 +10,7 @@ const modalReducer = createSlice({
     [MODALS.STUDY_MAKE_MODAL]: false,
     [MODALS.EVALUATION_MODAL]: false,
     [MODALS.INDUSTRY_SELECT_MODAL]: false,
+    [MODALS.WITHDRAW_CONFIRM_MODAL]: false,
   },
   reducers: {
     displayModal(state, { payload: { modalName } }) {

--- a/src/utils/constant.js
+++ b/src/utils/constant.js
@@ -5,4 +5,5 @@ export const MODALS = {
   STUDY_MAKE_MODAL: 'studyMakeModal',
   EVALUATION_MODAL: 'evaluationModal',
   INDUSTRY_SELECT_MODAL: 'industrySelectModal',
+  WITHDRAW_CONFIRM_MODAL: 'withdrawConfirmModal',
 };


### PR DESCRIPTION
✅ Closes: #116

> resolve #116 

## Detail & Solution
* 회원탈퇴 기능을 myPage 에 연동하였습니다.

## What I did
1. myPage 우측 하단에 `회원탈퇴 >` 텍스트를 추가 하였고, 클릭하면 탈퇴 확인 모달이 나오도록 구현하였습니다.
1. 해당 모달에 해당 계정의 패스워드를 입력하여 알맞으면 (패스워드-확인이 맞지 않거나 저장된 패스워드가 맞지 않거나, 그외 상황은 alert 으로 처리) 탈퇴 완료 alert 후 메인페이지로 이동되도록 구현했습니다.

## What I need to do

![image](https://user-images.githubusercontent.com/28996915/124480320-19caca80-dde2-11eb-96c6-cce88eb816a9.png)

* 위와 같이 우측 하단에 `회원 탈퇴 >` 를 클릭하면 해당 모달이 열립니다.
* 기존 기획에는 비밀번호 입력이 없어서 해당 형태로 우선 구현하고 추후 기획 및 디자인이 나오면 적용한다고 협의하였습니다.
