### PR TITLE
랜딩페이지 UI를 업데이트한다

### DIFF
--- a/src/components/atoms/Button/Button.js
+++ b/src/components/atoms/Button/Button.js
@@ -18,7 +18,7 @@ const Box = styled.div`
     }`}
   ${({ theme }) =>
     theme === 'blue'
-      ? 'background-image : linear-gradient(to bottom, #2323de -16%, #5f5fd9 122%);'
+      ? 'background-image : linear-gradient(to top, #2323de -16%, #5f5fd9 122%);'
       : theme === 'gray'
       ? 'background-color: #f6f6f6; pointer-events: none;'
       : theme === 'outline'

--- a/src/components/atoms/TextButton/TextButton.js
+++ b/src/components/atoms/TextButton/TextButton.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 const Text = styled.span`
   font-family: ${({ clicked }) =>
     clicked ? 'AppleSDGothicNeoEB00' : 'AppleSDGothicNeoM00'};
-  font-size: 1.9vh;
+  font-size: 13px;
   font-weight: normal;
   font-stretch: normal;
   font-style: normal;

--- a/src/hooks/useSocketSignal.js
+++ b/src/hooks/useSocketSignal.js
@@ -49,7 +49,9 @@ export default function useSocketSignal({ roomId, setStep }) {
     };
 
     peer.ontrack = ({ streams }) => {
-      setPeers((prevPeers) => prevPeers.filter((user) => user.id !== incomingSocketID));
+      setPeers((prevPeers) =>
+        prevPeers.filter((user) => user.id !== incomingSocketID),
+      );
       setPeers((prevPeers) => [
         ...prevPeers,
         {
@@ -105,37 +107,42 @@ export default function useSocketSignal({ roomId, setStep }) {
       });
     });
 
-    socketRef.current.on('getOffer', async ({ offerSendID, offerSendEmail, sdp: receiveSdp }) => {
-      createPeer(
-        offerSendID,
-        offerSendEmail,
-        socketRef.current.id,
-        userVideo.current.srcObject,
-      );
+    socketRef.current.on(
+      'getOffer',
+      async ({ offerSendID, offerSendEmail, sdp: receiveSdp }) => {
+        createPeer(
+          offerSendID,
+          offerSendEmail,
+          socketRef.current.id,
+          userVideo.current.srcObject,
+        );
 
-      const peer = peersRef.current.get(offerSendID);
+        const peer = peersRef.current.get(offerSendID);
 
-      if (peer) {
-        try {
-          await peer.setRemoteDescription(new RTCSessionDescription(receiveSdp));
+        if (peer) {
+          try {
+            await peer.setRemoteDescription(
+              new RTCSessionDescription(receiveSdp),
+            );
 
-          const sdp = await peer.createAnswer({
-            offerToReceiveVideo: true,
-            offerToReceiveAudio: true,
-          });
+            const sdp = await peer.createAnswer({
+              offerToReceiveVideo: true,
+              offerToReceiveAudio: true,
+            });
 
-          peer.setLocalDescription(new RTCSessionDescription(sdp));
+            peer.setLocalDescription(new RTCSessionDescription(sdp));
 
-          socketRef.current.emit('answer', {
-            sdp,
-            answerSendID: socketRef.current.id,
-            answerReceiveID: offerSendID,
-          });
-        } catch (error) {
-          alert(`error: ${error}`);
+            socketRef.current.emit('answer', {
+              sdp,
+              answerSendID: socketRef.current.id,
+              answerReceiveID: offerSendID,
+            });
+          } catch (error) {
+            alert(`error: ${error}`);
+          }
         }
-      }
-    });
+      },
+    );
 
     socketRef.current.on('getAnswer', ({ answerSendID, sdp }) => {
       const peer = peersRef.current.get(answerSendID);
@@ -145,17 +152,20 @@ export default function useSocketSignal({ roomId, setStep }) {
       }
     });
 
-    socketRef.current.on('getCandidate', async ({ candidateSendID, candidate }) => {
-      const peer = peersRef.current.get(candidateSendID);
+    socketRef.current.on(
+      'getCandidate',
+      async ({ candidateSendID, candidate }) => {
+        const peer = peersRef.current.get(candidateSendID);
 
-      if (peer) {
-        try {
-          await peer.addIceCandidate(new RTCIceCandidate(candidate));
-        } catch (error) {
-          alert(`candidate failed: ${error}`);
+        if (peer) {
+          try {
+            await peer.addIceCandidate(new RTCIceCandidate(candidate));
+          } catch (error) {
+            alert(`candidate failed: ${error}`);
+          }
         }
-      }
-    });
+      },
+    );
 
     socketRef.current.on('user left', ({ id }) => {
       peersRef.current.get(id).close();

--- a/src/pages/LandingPage/LandingBottom.js
+++ b/src/pages/LandingPage/LandingBottom.js
@@ -9,7 +9,7 @@ import TextBoxB from './components/TextBoxB';
 
 const Wrapper = styled.div`
   user-select: none;
-  height: 650px;
+  height: 750px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/pages/LandingPage/LandingHeader.js
+++ b/src/pages/LandingPage/LandingHeader.js
@@ -14,7 +14,7 @@ const Wrapper = styled.div`
   position: fixed;
   top: 0;
   width: 100%;
-  height: 60px;
+  height: 100px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -39,11 +39,11 @@ const Wrapper = styled.div`
     @media only screen and (max-width: 1150px) {
       display: none;
     }
-    min-width: 350px;
+    min-width: 521px;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding-right: 60px;
+    padding-right: 110px;
   }
 
   div.wrap-right-inner {
@@ -59,11 +59,9 @@ const Wrapper = styled.div`
 
   div.wrap-button {
     > div {
-      height: 35px;
-      border-radius: 5px;
       border-width: 1.5px;
       > p {
-        font-size: 12px;
+        font-size: 20px;
         font-family: AppleSDGothicNeoEB00;
       }
     }
@@ -121,7 +119,7 @@ export default function LandingHeader({
               <A.Button
                 id="menu_btn"
                 theme="outline"
-                width={140}
+                width={230}
                 text="LOG IN"
                 func={() => history.push('/login')}
               />

--- a/src/pages/LandingPage/LandingMiddleOne.js
+++ b/src/pages/LandingPage/LandingMiddleOne.js
@@ -28,7 +28,7 @@ const WrapContainer = styled.div`
   align-items: center;
   justify-content: space-around;
   margin-top: 75px;
-  margin-bottom: 75px;
+  margin-bottom: 90px;
 `;
 
 const WrapBottomContent = styled.div`

--- a/src/pages/LandingPage/LandingMiddleThree.js
+++ b/src/pages/LandingPage/LandingMiddleThree.js
@@ -12,7 +12,7 @@ import CircleButton from './components/CircleButton';
 
 const Wrapper = styled.div`
   @media only screen and (max-width: 1870px) {
-    min-height: 400px;
+    min-height: 500px;
   }
   width: 100%;
   user-select: none;
@@ -21,18 +21,18 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   overflow: hidden;
+  min-height: 850px;
 `;
 
 const WrapContainer = styled.div`
   @media only screen and (max-width: 1870px) {
-    width: 80%;
-    height: 400px;
+    height: 500px;
     justify-content: flex-start;
   }
   position: relative;
   height: 700px;
-  max-width: 1100px;
-  width: 80%;
+  max-width: 1150px;
+  width: 85%;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -40,7 +40,7 @@ const WrapContainer = styled.div`
 
 const WrapImage = styled.img`
   @media only screen and (max-width: 1870px) {
-    height: 350px;
+    height: 400px;
     bottom: 0px;
     right: -70px;
   }
@@ -63,7 +63,7 @@ const WrapPadding = styled.div`
 const WrapStaticImage = styled.img`
   @media only screen and (max-width: 1870px) {
     height: 300px;
-    right: -200px;
+    right: -250px;
     top: 50px;
   }
 
@@ -72,7 +72,7 @@ const WrapStaticImage = styled.img`
   height: 600px;
   position: absolute;
   top: 50px;
-  right: -400px;
+  right: -500px;
 `;
 
 const WrapCarousel = styled.div`

--- a/src/pages/LandingPage/LandingMiddleTwo.js
+++ b/src/pages/LandingPage/LandingMiddleTwo.js
@@ -8,11 +8,11 @@ import TextBoxA from './components/TextBoxA';
 
 const Wrapper = styled.div`
   @media only screen and (max-width: 1870px) {
-    min-height: 400px;
+    min-height: 500px;
   }
   width: 100%;
   user-select: none;
-  min-height: 500px;
+  min-height: 600px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -21,11 +21,11 @@ const Wrapper = styled.div`
 
 const WrapContainer = styled.div`
   @media only screen and (max-width: 1870px) {
-    min-height: 350px;
+    min-height: 500px;
   }
-  min-height: 475px;
-  width: 80%;
-  max-width: 1100px;
+  min-height: 600px;
+  width: 85%;
+  max-width: 1150px;
   min-width: 600px;
   position: relative;
   display: flex;
@@ -42,16 +42,16 @@ const WrapPadding = styled.div`
 
 const WrapImage = styled.img`
   @media only screen and (max-width: 1870px) {
-    height: 350px;
+    height: 400px;
     bottom: 0;
   }
   @media only screen and (max-width: 1150px) {
     display: none;
   }
 
-  height: 550px;
+  height: 600px;
   position: absolute;
-  bottom: -100px;
+  bottom: -80px;
   left: -100px;
 `;
 

--- a/src/pages/LandingPage/LandingTop.js
+++ b/src/pages/LandingPage/LandingTop.js
@@ -10,13 +10,13 @@ import TextBoxA from './components/TextBoxA';
 
 const Wrapper = styled.div`
   @media only screen and (max-width: 1150px) {
-    height: 550px;
+    height: 600px;
   }
   width: 100%;
   user-select: none;
-  height: 700px;
+  height: 750px;
   background-color: #f9f9ff;
-  padding-top: 60px;
+  padding-top: 100px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/LandingPage/components/TextButtonProps.js
+++ b/src/pages/LandingPage/components/TextButtonProps.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 const Text = styled.span`
   font-family: AppleSDGothicNeoEB00;
-  font-size: 13px;
+  font-size: 20px;
   font-weight: normal;
   font-stretch: normal;
   font-style: normal;


### PR DESCRIPTION
> resolve #124

## Detail & Solution
- useSocketSignal 파일은 git commit하면서 린트로 자동 포맷팅되었습니다
- 제플린에서 보이는 사이즈 (가로 1920px)를 주로 확인하면서 작업했습니다
- 주셨던 수정사항 기반으로 간격, 너비 등은 현재 제플린을 반영했는데, 비교하다가 추가적으로 수정이 필요할 것 같은 부분은 아직 작업하지 않아서 이슈로 넣겠습니다
## What I did
1. 상단 네비게이션바 height 100px
2. 상단 네비게이션 바 font size는 20px 
3. 메인 일러스트 있는 쪽의 시작하기 버튼의 그라데이션이 반대로 되어 있어서 수정 => `기존에 zeplin의 css를 복사했던것같은데 왜 반대로 되어있는지 이상하네요`
4. 집에서 편리하게 경험... 페이지의 div height도 높임
5. 나를 위한 효과적인... div margin bottom도 좀 더 높임
6. 혼자서도 쉽게... div min height도 높임
7. 다른사람들과 함께.... div height도 키움
그리고 여기 텍스트랑 이미지 사이의 간격이 조금 가까운데 혹시 사이를 넓  -> 전체적인 폭을 넓힘
또 배경에 있는 로고 (w)가 좀 더 오른쪽으로 (로고가 잘려도 됨)
또한 페이지 인디케이터가 이미지와 가깝게 붙이기 -> 이미지 크기가 커지면서 좀 더 붙음
8. 면접은 더 편하게... 여기랑 푸터와의 간격을 더 넓힘 -> 제플린 참고하여 위아래 간격을 넓힘
9. 푸터 이용약관, 개인정보처리방침 텍스트를 13px로 수정

## What I need to do
- 발견한 다른 수정사항 이슈등록: #127 
